### PR TITLE
Avoid clearing s_telemetryInterval when an invalid parameter is received

### DIFF
--- a/iot-hub/Quickstarts/simulated-device-2/SimulatedDevice.cs
+++ b/iot-hub/Quickstarts/simulated-device-2/SimulatedDevice.cs
@@ -29,8 +29,9 @@ namespace simulated_device
             var data = Encoding.UTF8.GetString(methodRequest.Data);
 
             // Check the payload is a single integer value
-            if (Int32.TryParse(data, out s_telemetryInterval))
+            if (Int32.TryParse(data, out int telemetryInterval))
             {
+                s_telemetryInterval = telemetryInterval;
                 Console.ForegroundColor = ConsoleColor.Green;
                 Console.WriteLine("Telemetry interval set to {0} seconds", data);
                 Console.ResetColor();


### PR DESCRIPTION
## Purpose
In current implementation, when an invalid parameter is received, the internal will be reset to be zero, which makes the simulated device send message to cloud very fast.
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->