### PR TITLE
Removing timeouts and looping forever in device streams proxy samples.

### DIFF
--- a/iot-hub/Quickstarts/device-streams-proxy/device/DeviceStreamSample.cs
+++ b/iot-hub/Quickstarts/device-streams-proxy/device/DeviceStreamSample.cs
@@ -51,12 +51,23 @@ namespace Microsoft.Azure.Devices.Client.Samples
 
         public async Task RunSampleAsync()
         {
-            await RunSampleAsync(true).ConfigureAwait(false);
+            while (true)
+            {
+                try
+                {
+                    await RunSampleAsync(true).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine("Got an exception: {0}", ex);
+                }
+                Console.WriteLine("Waiting again...");
+            }
         }
 
         public async Task RunSampleAsync(bool acceptDeviceStreamingRequest)
         {
-            using (var cancellationTokenSource = new CancellationTokenSource(new TimeSpan(0, 5, 0)))
+            using (var cancellationTokenSource = new CancellationTokenSource())
             {
                 DeviceStreamRequest streamRequest = await _deviceClient.WaitForDeviceStreamRequestAsync(cancellationTokenSource.Token).ConfigureAwait(false);
 

--- a/iot-hub/Quickstarts/device-streams-proxy/device/DeviceStreamSample.cs
+++ b/iot-hub/Quickstarts/device-streams-proxy/device/DeviceStreamSample.cs
@@ -49,13 +49,13 @@ namespace Microsoft.Azure.Devices.Client.Samples
             }
         }
 
-        public async Task RunSampleAsync()
+        public async Task RunSampleAsync(CancellationTokenSource cancellationTokenSource)
         {
-            while (true)
+            while (!cancellationTokenSource.IsCancellationRequested)
             {
                 try
                 {
-                    await RunSampleAsync(true).ConfigureAwait(false);
+                    await RunSampleAsync(true, cancellationTokenSource).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
@@ -65,43 +65,40 @@ namespace Microsoft.Azure.Devices.Client.Samples
             }
         }
 
-        public async Task RunSampleAsync(bool acceptDeviceStreamingRequest)
+        public async Task RunSampleAsync(bool acceptDeviceStreamingRequest, CancellationTokenSource cancellationTokenSource)
         {
-            using (var cancellationTokenSource = new CancellationTokenSource())
+            DeviceStreamRequest streamRequest = await _deviceClient.WaitForDeviceStreamRequestAsync(cancellationTokenSource.Token).ConfigureAwait(false);
+
+            if (streamRequest != null)
             {
-                DeviceStreamRequest streamRequest = await _deviceClient.WaitForDeviceStreamRequestAsync(cancellationTokenSource.Token).ConfigureAwait(false);
-
-                if (streamRequest != null)
+                if (acceptDeviceStreamingRequest)
                 {
-                    if (acceptDeviceStreamingRequest)
-                    {
-                        await _deviceClient.AcceptDeviceStreamRequestAsync(streamRequest, cancellationTokenSource.Token).ConfigureAwait(false);
+                    await _deviceClient.AcceptDeviceStreamRequestAsync(streamRequest, cancellationTokenSource.Token).ConfigureAwait(false);
 
-                        using (ClientWebSocket webSocket = await DeviceStreamingCommon.GetStreamingClientAsync(streamRequest.Url, streamRequest.AuthorizationToken, cancellationTokenSource.Token).ConfigureAwait(false))
+                    using (ClientWebSocket webSocket = await DeviceStreamingCommon.GetStreamingClientAsync(streamRequest.Url, streamRequest.AuthorizationToken, cancellationTokenSource.Token).ConfigureAwait(false))
+                    {
+                        using (TcpClient tcpClient = new TcpClient())
                         {
-                            using (TcpClient tcpClient = new TcpClient())
+                            await tcpClient.ConnectAsync(_host, _port).ConfigureAwait(false);
+
+                            using (NetworkStream localStream = tcpClient.GetStream())
                             {
-                                await tcpClient.ConnectAsync(_host, _port).ConfigureAwait(false);
+                                Console.WriteLine("Starting streaming");
 
-                                using (NetworkStream localStream = tcpClient.GetStream())
-                                {
-                                    Console.WriteLine("Starting streaming");
+                                await Task.WhenAny(
+                                    HandleIncomingDataAsync(localStream, webSocket, cancellationTokenSource.Token),
+                                    HandleOutgoingDataAsync(localStream, webSocket, cancellationTokenSource.Token)).ConfigureAwait(false);
 
-                                    await Task.WhenAny(
-                                        HandleIncomingDataAsync(localStream, webSocket, cancellationTokenSource.Token),
-                                        HandleOutgoingDataAsync(localStream, webSocket, cancellationTokenSource.Token)).ConfigureAwait(false);
-
-                                    localStream.Close();
-                                }
+                                localStream.Close();
                             }
-
-                            await webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, String.Empty, cancellationTokenSource.Token).ConfigureAwait(false);
                         }
+
+                        await webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, String.Empty, cancellationTokenSource.Token).ConfigureAwait(false);
                     }
-                    else
-                    {
-                        await _deviceClient.RejectDeviceStreamRequestAsync(streamRequest, cancellationTokenSource.Token).ConfigureAwait(false);
-                    }
+                }
+                else
+                {
+                    await _deviceClient.RejectDeviceStreamRequestAsync(streamRequest, cancellationTokenSource.Token).ConfigureAwait(false);
                 }
             }
         }

--- a/iot-hub/Quickstarts/device-streams-proxy/device/Program.cs
+++ b/iot-hub/Quickstarts/device-streams-proxy/device/Program.cs
@@ -31,8 +31,8 @@ namespace Microsoft.Azure.Devices.Client.Samples
         private static string s_port = Environment.GetEnvironmentVariable("REMOTE_PORT");
 
         // Select one of the following transports used by DeviceClient to connect to IoT Hub.
-        private static TransportType s_transportType = TransportType.Amqp;
-        //private static TransportType s_transportType = TransportType.Mqtt;
+        //private static TransportType s_transportType = TransportType.Amqp;
+        private static TransportType s_transportType = TransportType.Mqtt;
         //private static TransportType s_transportType = TransportType.Amqp_WebSocket_Only;
         //private static TransportType s_transportType = TransportType.Mqtt_WebSocket_Only;
 

--- a/iot-hub/Quickstarts/device-streams-proxy/device/Program.cs
+++ b/iot-hub/Quickstarts/device-streams-proxy/device/Program.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using System.Threading;
 
 namespace Microsoft.Azure.Devices.Client.Samples
 {
@@ -31,8 +32,8 @@ namespace Microsoft.Azure.Devices.Client.Samples
         private static string s_port = Environment.GetEnvironmentVariable("REMOTE_PORT");
 
         // Select one of the following transports used by DeviceClient to connect to IoT Hub.
-        //private static TransportType s_transportType = TransportType.Amqp;
-        private static TransportType s_transportType = TransportType.Mqtt;
+        private static TransportType s_transportType = TransportType.Amqp;
+        //private static TransportType s_transportType = TransportType.Mqtt;
         //private static TransportType s_transportType = TransportType.Amqp_WebSocket_Only;
         //private static TransportType s_transportType = TransportType.Mqtt_WebSocket_Only;
 
@@ -73,7 +74,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
                 }
 
                 var sample = new DeviceStreamSample(deviceClient, s_hostName, port);
-                sample.RunSampleAsync().GetAwaiter().GetResult();
+                sample.RunSampleAsync(new CancellationTokenSource()).GetAwaiter().GetResult();
             }
 
             Console.WriteLine("Done.\n");

--- a/iot-hub/Quickstarts/device-streams-proxy/service/DeviceStreamSample.cs
+++ b/iot-hub/Quickstarts/device-streams-proxy/service/DeviceStreamSample.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.Devices.Samples
                 {
                     try
                     {
-                        using (var cancellationTokenSource = new CancellationTokenSource(new TimeSpan(0, 1, 0)))
+                        using (var cancellationTokenSource = new CancellationTokenSource())
                         using (var remoteStream = await DeviceStreamingCommon.GetStreamingClientAsync(result.Url, result.AuthorizationToken, cancellationTokenSource.Token).ConfigureAwait(false))
                         {
                             Console.WriteLine("Starting streaming");


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Remove timeouts in the device and service local proxy
* Make device local proxy loop forever (still some error conditions are not handled)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ X ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ X ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code
Follow instructions [here](https://docs.microsoft.com/en-us/azure/iot-hub/quickstart-device-streams-proxy-csharp#ssh-to-a-device-via-device-streams)


* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* Timeouts removed
* Device local proxy loops forever

## Other Information
<!-- Add any other helpful information that may be needed here. -->