### PR TITLE
Need to close  the stream  and improved buffer code.

### DIFF
--- a/iot-hub/Quickstarts/device-streams-echo/service/DeviceStreamSample.cs
+++ b/iot-hub/Quickstarts/device-streams-echo/service/DeviceStreamSample.cs
@@ -40,15 +40,20 @@ namespace Microsoft.Azure.Devices.Samples
                     using (var stream = await DeviceStreamingCommon.GetStreamingClientAsync(result.Url, result.AuthorizationToken, cancellationTokenSource.Token).ConfigureAwait(false))
                     {
                         byte[] sendBuffer = Encoding.UTF8.GetBytes("Streaming data over a stream...");
+                        System.ArraySegment<byte> SendBuffer = new ArraySegment<byte>(sendBuffer);
                         byte[] receiveBuffer = new byte[1024];
+                        System.ArraySegment<byte> ReceiveBuffer = new ArraySegment<byte>(receiveBuffer);
+                        
+                        await stream.SendAsync(SendBuffer, WebSocketMessageType.Binary, true, cancellationTokenSource.Token).ConfigureAwait(false);
 
-                        await stream.SendAsync(sendBuffer, WebSocketMessageType.Binary, true, cancellationTokenSource.Token).ConfigureAwait(false);
+                        Console.WriteLine("Service Sent stream data: {0}", Encoding.UTF8.GetString(SendBuffer.ToArray(), 0, SendBuffer.Count));
 
-                        Console.WriteLine("Sent stream data: {0}", Encoding.UTF8.GetString(sendBuffer, 0, sendBuffer.Length));
+                        var receiveResult = await stream.ReceiveAsync(ReceiveBuffer, cancellationTokenSource.Token).ConfigureAwait(false);
 
-                        var receiveResult = await stream.ReceiveAsync(receiveBuffer, cancellationTokenSource.Token).ConfigureAwait(false);
+                        Console.WriteLine("Received stream data: {0}", Encoding.UTF8.GetString(ReceiveBuffer.ToArray(), 0, receiveResult.Count));
+                    
+                        await stream.CloseAsync(WebSocketCloseStatus.NormalClosure, String.Empty, cancellationTokenSource.Token).ConfigureAwait(false);
 
-                        Console.WriteLine("Received stream data: {0}", Encoding.UTF8.GetString(receiveBuffer, 0, receiveResult.Count));
                     }
                 }
                 else


### PR DESCRIPTION
Inserted stream socket closure code in service as per the device as the device reports incorrect closure at this end.

Improved buffer coding in service in line with that in device. Required for .Net Standard compilation.

## Purpose
First change removes an error/warning that can occur. The second tightens up the code.


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe:
Enables code to be built as a .Net Standard library, when refactored


## How to Test
*  Get the code

```
git clone https://github.com/djaus2/AziothubDeviceStreaming.git
cd AziothubDeviceStreaming
git checkout Master
npm install
```

* Test the code
Set target to Any CPU and configure to run multiple projects 
- DNCore_OrigEchoSample_DeviceClientStreaming  and
- DNCore_OrigEchoSample_ServiceClientStreaming
Need to create an IoT Hub and add settings to AzureConnections.cs in Solution common folder (or in DNCore_AzureConnections project)

## What to Check
Verify that the following are valid
Consoles should display that the Service passes a message, the device reads it and returns it.. And the service gets it back. In my project the device uppercases the message.

## Other Information
You might like to try the refactored projects:
DNCore_DeviceApp and  DNCore_ServiceApp