### PR TITLE
Update 'rules' in scripts to 'queries'.

### DIFF
--- a/iot-hub/Tutorials/Routing/SimulatedDevice/resources/iothub_msgenrichment_cli.azcli
+++ b/iot-hub/Tutorials/Routing/SimulatedDevice/resources/iothub_msgenrichment_cli.azcli
@@ -1,5 +1,5 @@
 # This command retrieves the subscription id of the current Azure account.
-# This field is used when setting up the routing rules.
+# This field is used when setting up the routing queries.
 subscriptionID=$(az account show --query id -o tsv)
 
 # Concatenate this number onto the resources that have to be globally unique.

--- a/iot-hub/Tutorials/Routing/SimulatedDevice/resources/iothub_routing_cli.azcli
+++ b/iot-hub/Tutorials/Routing/SimulatedDevice/resources/iothub_routing_cli.azcli
@@ -1,5 +1,5 @@
 ﻿# This command retrieves the subscription id of the current Azure account.
-# This field is used when setting up the routing rules.
+# This field is used when setting up the routing queries.
 subscriptionID=$(az account show --query id -o tsv)
 
 # Concatenate this number onto the resources that have to be globally unique.

--- a/iot-hub/Tutorials/Routing/SimulatedDevice/resources/iothub_routing_psh.ps1
+++ b/iot-hub/Tutorials/Routing/SimulatedDevice/resources/iothub_routing_psh.ps1
@@ -1,5 +1,5 @@
 ﻿# This retrieves the subscription id of the current Azure account.
-# This field is used when setting up the routing rules.
+# This field is used when setting up the routing queries.
 $subscriptionID = (Get-AzureRmContext).Subscription.Id
 
 # Concatenate this number onto the resources that have to be globally unique.


### PR DESCRIPTION
Replaces "rules" in the scripts with the word "queries" to be accurate and match the articles that use these scripts.