### PR TITLE
Update digital twin samples to support net core 3.0

### DIFF
--- a/digitaltwin/Samples/device/EnvironmentSensorLib/EnvironmentalSensorLib.csproj
+++ b/digitaltwin/Samples/device/EnvironmentSensorLib/EnvironmentalSensorLib.csproj
@@ -5,6 +5,7 @@
     <TargetFrameworks>netcoreapp2.2; netcoreapp3.0</TargetFrameworks>
     <ApplicationIcon />
     <StartupObject />
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/digitaltwin/Samples/device/EnvironmentSensorLib/EnvironmentalSensorLib.csproj
+++ b/digitaltwin/Samples/device/EnvironmentSensorLib/EnvironmentalSensorLib.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFrameworks>netcoreapp2.2; netcoreapp3.0</TargetFrameworks>
     <ApplicationIcon />
     <StartupObject />
   </PropertyGroup>

--- a/digitaltwin/Samples/device/EnvironmentalSensorSample/EnvironmentalSensorSample.csproj
+++ b/digitaltwin/Samples/device/EnvironmentalSensorSample/EnvironmentalSensorSample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFrameworks>netcoreapp2.2; netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/digitaltwin/Samples/device/EnvironmentalSensorSample/EnvironmentalSensorSample.csproj
+++ b/digitaltwin/Samples/device/EnvironmentalSensorSample/EnvironmentalSensorSample.csproj
@@ -9,4 +9,10 @@
     <ProjectReference Include="..\EnvironmentSensorLib\EnvironmentalSensorLib.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Include="EnvironmentalSensor.interface.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
+  </ItemGroup>
+  
 </Project>

--- a/digitaltwin/Samples/device/EnvironmentalSensorSample/EnvironmentalSensorSample.csproj
+++ b/digitaltwin/Samples/device/EnvironmentalSensorSample/EnvironmentalSensorSample.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp2.2; netcoreapp3.0</TargetFrameworks>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/digitaltwin/Samples/device/EnvironmentalSensorSample/ModelDefinitionInterface.cs
+++ b/digitaltwin/Samples/device/EnvironmentalSensorSample/ModelDefinitionInterface.cs
@@ -35,11 +35,11 @@ namespace EnvironmentalSensorSample
             }
         }
 
-                              /// <summary>
-                              /// Callback on command received.
-                              /// </summary>
-                              /// <param name="commandRequest">information regarding the command received.</param>
-                              /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <summary>
+        /// Callback on command received.
+        /// </summary>
+        /// <param name="commandRequest">information regarding the command received.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override Task<DigitalTwinCommandResponse> OnCommandRequest(DigitalTwinCommandRequest commandRequest)
         {
             // There is only one command that ModelDefinition defines, and it is getModelDefinition. That command must specify the 

--- a/digitaltwin/Samples/device/EnvironmentalSensorSample/ModelDefinitionInterface.cs
+++ b/digitaltwin/Samples/device/EnvironmentalSensorSample/ModelDefinitionInterface.cs
@@ -28,11 +28,10 @@ namespace EnvironmentalSensorSample
             var assembly = Assembly.GetExecutingAssembly();
             var assemblyResourceName = EnvironmentalSensorInterfaceFileAssemblyName + "." + EnvironmentalSensorInterfaceFileName;
 
-            using (Stream stream = assembly.GetManifestResourceStream(assemblyResourceName))
-            using (StreamReader reader = new StreamReader(stream))
-            {
-                this.environmentalSensorModelDefinition = reader.ReadToEnd();
-            }
+            using Stream stream = assembly.GetManifestResourceStream(assemblyResourceName);
+            using StreamReader reader = new StreamReader(stream);
+            
+            this.environmentalSensorModelDefinition = reader.ReadToEnd();
         }
 
         /// <summary>
@@ -49,11 +48,11 @@ namespace EnvironmentalSensorSample
                 string commandPayload = JsonConvert.DeserializeObject<string>(commandRequest.Payload);
                 if (commandPayload.Equals(EnvironmentalSensorInterface.EnvironmentalSensorInterfaceId))
                 {
-                    return Task<DigitalTwinCommandResponse>.Factory.StartNew(() => new DigitalTwinCommandResponse(StatusCodeCompleted, this.environmentalSensorModelDefinition));
+                    return Task.FromResult(new DigitalTwinCommandResponse(StatusCodeCompleted, this.environmentalSensorModelDefinition));
                 }
             }
 
-            return Task<DigitalTwinCommandResponse>.Factory.StartNew(() => new DigitalTwinCommandResponse(StatusCodeNotImplemented, null));
+            return Task.FromResult(new DigitalTwinCommandResponse(StatusCodeNotImplemented, null));
         }
     }
 }

--- a/digitaltwin/Samples/device/EnvironmentalSensorSample/ModelDefinitionInterface.cs
+++ b/digitaltwin/Samples/device/EnvironmentalSensorSample/ModelDefinitionInterface.cs
@@ -35,14 +35,12 @@ namespace EnvironmentalSensorSample
             }
         }
 
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
                               /// <summary>
                               /// Callback on command received.
                               /// </summary>
                               /// <param name="commandRequest">information regarding the command received.</param>
                               /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        protected override async Task<DigitalTwinCommandResponse> OnCommandRequest(DigitalTwinCommandRequest commandRequest)
-#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+        protected override Task<DigitalTwinCommandResponse> OnCommandRequest(DigitalTwinCommandRequest commandRequest)
         {
             // There is only one command that ModelDefinition defines, and it is getModelDefinition. That command must specify the 
             // model Id in the payload, and the device must return the model definition in the command response payload
@@ -51,11 +49,11 @@ namespace EnvironmentalSensorSample
                 string commandPayload = JsonConvert.DeserializeObject<string>(commandRequest.Payload);
                 if (commandPayload.Equals(EnvironmentalSensorInterface.EnvironmentalSensorInterfaceId))
                 {
-                    return new DigitalTwinCommandResponse(StatusCodeCompleted, this.environmentalSensorModelDefinition);
+                    return Task<DigitalTwinCommandResponse>.Factory.StartNew(() => new DigitalTwinCommandResponse(StatusCodeCompleted, this.environmentalSensorModelDefinition));
                 }
             }
 
-            return new DigitalTwinCommandResponse(StatusCodeNotImplemented, null);
+            return Task<DigitalTwinCommandResponse>.Factory.StartNew(() => new DigitalTwinCommandResponse(StatusCodeNotImplemented, null));
         }
     }
 }

--- a/digitaltwin/Samples/device/EnvironmentalSensorSample/ModelDefinitionInterface.cs
+++ b/digitaltwin/Samples/device/EnvironmentalSensorSample/ModelDefinitionInterface.cs
@@ -35,12 +35,14 @@ namespace EnvironmentalSensorSample
             }
         }
 
-        /// <summary>
-        /// Callback on command received.
-        /// </summary>
-        /// <param name="commandRequest">information regarding the command received.</param>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+                              /// <summary>
+                              /// Callback on command received.
+                              /// </summary>
+                              /// <param name="commandRequest">information regarding the command received.</param>
+                              /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override async Task<DigitalTwinCommandResponse> OnCommandRequest(DigitalTwinCommandRequest commandRequest)
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
         {
             // There is only one command that ModelDefinition defines, and it is getModelDefinition. That command must specify the 
             // model Id in the payload, and the device must return the model definition in the command response payload

--- a/digitaltwin/Samples/device/EnvironmentalSensorSample/ModelDefinitionInterface.cs
+++ b/digitaltwin/Samples/device/EnvironmentalSensorSample/ModelDefinitionInterface.cs
@@ -2,6 +2,7 @@
 using Microsoft.Azure.Devices.DigitalTwin.Client.Model;
 using Newtonsoft.Json;
 using System.IO;
+using System.Reflection;
 using System.Threading.Tasks;
 
 namespace EnvironmentalSensorSample
@@ -18,10 +19,20 @@ namespace EnvironmentalSensorSample
 
         private const string getModelDefinitionCommandName = "getModelDefinition";
 
+        private const string EnvironmentalSensorInterfaceFileName = "EnvironmentalSensor.interface.json";
+        private const string EnvironmentalSensorInterfaceFileAssemblyName = "EnvironmentalSensorSample";
+
         public ModelDefinitionInterface(string interfaceInstanceName)
             : base(ModelDefinitionInterfaceId, interfaceInstanceName)
         {
-            environmentalSensorModelDefinition = File.ReadAllText("../../../EnvironmentalSensor.interface.json");
+            var assembly = Assembly.GetExecutingAssembly();
+            var assemblyResourceName = EnvironmentalSensorInterfaceFileAssemblyName + "." + EnvironmentalSensorInterfaceFileName;
+
+            using (Stream stream = assembly.GetManifestResourceStream(assemblyResourceName))
+            using (StreamReader reader = new StreamReader(stream))
+            {
+                this.environmentalSensorModelDefinition = reader.ReadToEnd();
+            }
         }
 
         /// <summary>

--- a/digitaltwin/Samples/service/GetDigitalTwin/GetDigitalTwin.csproj
+++ b/digitaltwin/Samples/service/GetDigitalTwin/GetDigitalTwin.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFrameworks>netcoreapp2.2; netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/digitaltwin/Samples/service/GetModel/GetModel.csproj
+++ b/digitaltwin/Samples/service/GetModel/GetModel.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFrameworks>netcoreapp2.2; netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/digitaltwin/Samples/service/InvokeAsyncCommand/InvokeAsyncCommand.csproj
+++ b/digitaltwin/Samples/service/InvokeAsyncCommand/InvokeAsyncCommand.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFrameworks>netcoreapp2.2; netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/digitaltwin/Samples/service/InvokeCommand/InvokeCommand.csproj
+++ b/digitaltwin/Samples/service/InvokeCommand/InvokeCommand.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFrameworks>netcoreapp2.2; netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/digitaltwin/Samples/service/UpdateProperty/UpdateProperty.csproj
+++ b/digitaltwin/Samples/service/UpdateProperty/UpdateProperty.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFrameworks>netcoreapp2.2; netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Previously only supported net core 2.2, but now supports both 2.2 and 3.0

