### PR TITLE
Fix ADM samples

### DIFF
--- a/iot-hub/Samples/service/AutomaticDeviceManagementSample/AutomaticDeviceManagementSample.cs
+++ b/iot-hub/Samples/service/AutomaticDeviceManagementSample/AutomaticDeviceManagementSample.cs
@@ -1,15 +1,18 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.Devices;
 
 namespace Microsoft.Azure.Devices.Samples
 {
+    /// <summary>
+    /// This sample demonstrates automatic device management using device configurations.
+    /// For module configurations, refer to: https://github.com/Azure-Samples/azure-iot-samples-csharp/tree/master/iot-hub/Samples/service/EdgeDeploymentSample
+    /// </summary>
     public class AutomaticDeviceManagementSample
     {
         private readonly RegistryManager _registryManager;
@@ -47,117 +50,54 @@ namespace Microsoft.Azure.Devices.Samples
             await GetConfigurations(5).ConfigureAwait(false);
         }
 
-        public async Task AddDeviceConfiguration(string configurationId)
+        private async Task AddDeviceConfiguration(string configurationId)
         {
             Configuration configuration = new Configuration(configurationId);
 
             CreateDeviceContent(configuration, configurationId);
-            CreateModulesContent(configuration, configurationId);
             CreateMetricsAndTargetCondition(configuration, configurationId);
 
             await _registryManager.AddConfigurationAsync(configuration).ConfigureAwait(false);
 
-            Console.WriteLine("Configuration added, id: " + configurationId);
+            Console.WriteLine($"Configuration added, id: {configurationId}");
         }
 
-        public void CreateDeviceContent(Configuration configuration, string configurationId)
+        private void CreateDeviceContent(Configuration configuration, string configurationId)
         {
-            configuration.Content = new ConfigurationContent();
-            configuration.Content.DeviceContent = new Dictionary<string, object>();
+            configuration.Content = new ConfigurationContent
+            {
+                DeviceContent = new Dictionary<string, object>()
+            };
             configuration.Content.DeviceContent["properties.desired.deviceContent_key"] = "deviceContent_value-" + configurationId;
         }
 
-        public void CreateModulesContent(Configuration configuration, string configurationId)
-        {
-            configuration.Content.ModulesContent = new Dictionary<string, IDictionary<string, object>>();
-            IDictionary<string, object> modules_value = new Dictionary<string, object>();
-            modules_value["properties.desired.modulesContent_key"] = "modulesContent_value-" + configurationId;
-            configuration.Content.ModulesContent["properties.desired.modules_key"] = modules_value;
-        }
-
-        public void CreateMetricsAndTargetCondition(Configuration configuration, string configurationId)
+        private void CreateMetricsAndTargetCondition(Configuration configuration, string configurationId)
         {
             configuration.Metrics.Queries.Add("waterSettingsPending", "SELECT deviceId FROM devices WHERE properties.reported.chillerWaterSettings.status=\'pending\'");
             configuration.TargetCondition = "properties.reported.chillerProperties.model=\'4000x\'";
             configuration.Priority = 20;
         }
 
-        public async Task DeleteConfiguration(string configurationId)
+        private async Task DeleteConfiguration(string configurationId)
         {
             await _registryManager.RemoveConfigurationAsync(configurationId).ConfigureAwait(false);
 
-            Console.WriteLine("Configuration deleted, id: " + configurationId);
+            Console.WriteLine($"Configuration deleted, id: {configurationId}");
         }
 
-        public async Task GetConfigurations(int count)
+        private async Task GetConfigurations(int count)
         {
             IEnumerable<Configuration> configurations = await _registryManager.GetConfigurationsAsync(count).ConfigureAwait(false);
 
             // Check configuration's metrics for expected conditions
             foreach (var configuration in configurations)
             {
-                PrintConfiguration(configuration);
+                string configurationString = JsonConvert.SerializeObject(configuration, Formatting.Indented);
+                Console.WriteLine(configurationString);
                 Thread.Sleep(1000);
             }
 
             Console.WriteLine("Configurations received");
-        }
-
-        public void PrintConfiguration(Configuration configuration)
-        {
-            Console.WriteLine("Configuration Id: " + configuration.Id);
-            Console.WriteLine("Configuration SchemaVersion: " + configuration.SchemaVersion);
-
-            Console.WriteLine("Configuration Labels: " + configuration.Labels);
-
-            PrintContent(configuration.ContentType, configuration.Content);
-
-            Console.WriteLine("Configuration TargetCondition: " + configuration.TargetCondition);
-            Console.WriteLine("Configuration CreatedTimeUtc: " + configuration.CreatedTimeUtc);
-            Console.WriteLine("Configuration LastUpdatedTimeUtc: " + configuration.LastUpdatedTimeUtc);
-
-            Console.WriteLine("Configuration Priority: " + configuration.Priority);
-
-            PrintConfigurationMetrics(configuration.SystemMetrics, "SystemMetrics");
-            PrintConfigurationMetrics(configuration.Metrics, "Metrics");
-
-            Console.WriteLine("Configuration ETag: " + configuration.ETag);
-            Console.WriteLine("------------------------------------------------------------");
-        }
-
-        private void PrintContent(string contentType, ConfigurationContent configurationContent)
-        {
-            Console.WriteLine($"Configuration Content [type = {contentType}]");
-
-            Console.WriteLine("ModuleContent:");
-            foreach (string modulesContentKey in configurationContent.ModulesContent.Keys)
-            {
-                foreach (string key in configurationContent.ModulesContent[modulesContentKey].Keys)
-                {
-                    Console.WriteLine($"\t\t{key} = {configurationContent.ModulesContent[modulesContentKey][key]}");
-                }
-            }
-
-            Console.WriteLine("DeviceContent:");
-            foreach (string key in configurationContent.DeviceContent.Keys)
-            {
-                Console.WriteLine($"\t{key} = {configurationContent.DeviceContent[key]}");
-            }
-        }
-
-        private void PrintConfigurationMetrics(ConfigurationMetrics metrics, string title)
-        {
-            Console.WriteLine($"{title} Results: ({metrics.Results.Count})");
-            foreach (string key in metrics.Results.Keys)
-            {
-                Console.WriteLine($"\t{key} = {metrics.Results[key]}");
-            }
-
-            Console.WriteLine($"{title} Queries: ({metrics.Queries.Count})");
-            foreach (string key in metrics.Queries.Keys)
-            {
-                Console.WriteLine($"\t{key} = {metrics.Queries[key]}");
-            }
         }
     }
 }

--- a/iot-hub/Samples/service/AutomaticDeviceManagementSample/AutomaticDeviceManagementSample.csproj
+++ b/iot-hub/Samples/service/AutomaticDeviceManagementSample/AutomaticDeviceManagementSample.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/iot-hub/Samples/service/AutomaticDeviceManagementSample/Program.cs
+++ b/iot-hub/Samples/service/AutomaticDeviceManagementSample/Program.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Threading.Tasks;
 
 namespace Microsoft.Azure.Devices.Samples
 {
@@ -16,21 +17,20 @@ namespace Microsoft.Azure.Devices.Samples
 
         private static string s_connectionString = Environment.GetEnvironmentVariable("IOTHUB_CONN_STRING_CSHARP");
 
-        public static int Main(string[] args)
+        public static async Task Main(string[] args)
         {
             if (string.IsNullOrEmpty(s_connectionString) && args.Length > 0)
             {
                 s_connectionString = args[0];
             }
 
-            RegistryManager registryManager = RegistryManager.CreateFromConnectionString(s_connectionString);
+            using var registryManager = RegistryManager.CreateFromConnectionString(s_connectionString);
 
             var sample = new AutomaticDeviceManagementSample(registryManager);
 
-            sample.RunSampleAsync().GetAwaiter().GetResult();
+            await sample.RunSampleAsync().ConfigureAwait(false);
 
             Console.WriteLine("Done.\n");
-            return 0;
         }
     }
 }


### PR DESCRIPTION
The ADM samples used an incorrect configuration to create module configurations. Device configurations and module configurations need to be created separately, since the target condition for the configuration has different requirements for devices and modules. 
This sample deals only with creating device configurations.
Sample for module configurations is present here: https://github.com/Azure-Samples/azure-iot-samples-csharp/tree/master/iot-hub/Samples/service/EdgeDeploymentSample