### PR TITLE
added more allowed characters to registration id validation

### DIFF
--- a/provisioning/Samples/device/Common/ProvisioningDeviceClientSample.cs
+++ b/provisioning/Samples/device/Common/ProvisioningDeviceClientSample.cs
@@ -69,10 +69,10 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Samples
 
         private void VerifyRegistrationIdFormat(string v)
         {
-            var r = new Regex("^[a-z0-9-]*$");
+            var r = new Regex(@"^[A-Za-z0-9:\._-]*$");
             if (!r.IsMatch(v))
             {
-                throw new FormatException("Invalid registrationId: The registration ID is alphanumeric, lowercase, and may contain hyphens");
+                throw new FormatException("Invalid registrationId: The registration ID is alphanumeric, case insensitive, and may contain special characters including colon, period, underscore and hyphen.");
             }
         }
     }


### PR DESCRIPTION
## Purpose

During my tests I wondered why I got an FormatException following the guidelines on https://docs.microsoft.com/en-gb/azure/iot-dps/concepts-device where it is stated that: 

> The registration ID is alphanumeric, case insensitive, and may contain special characters including colon, period, underscore and hyphen.

Then I noticed that the code throwing this exception was copied from this example.

I first created an issue in the docs repo (https://github.com/MicrosoftDocs/azure-docs/issues/52813). But according to @nberdy it turned out the example is outdated.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ x ] No
```

## Pull Request Type

<!-- Please check the one that applies to this PR using "x". -->
```
[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Register a device with a registration id containing a upper case letter

## Other Information
<!-- Add any other helpful information that may be needed here. -->