### PR TITLE
[Samples] Migrate "Read device-to-cloud" to the new Event Hubs client

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ azure-iot-samples-csharp provides a set of easy-to-understand, continuously-test
 
 ## Prerequisites
 
-- .NET Core SDK 2.1.0 or greater on your development machine.  You can download the .NET Core SDK for multiple platforms from [.NET](https://www.microsoft.com/net/download/all).  You can verify the current version of C# on your development machine using 'dotnet --version'.
+- .NET Core SDK 3.0.0 or greater on your development machine.  You can download the .NET Core SDK for multiple platforms from [.NET](https://www.microsoft.com/net/download/all).  You can verify the current version of C# on your development machine using 'dotnet --version'.
+
+  **Note:** The samples can be compiled using the NET Core SDK 2.1 SDK if the language version of projects using C# 8 features are changed to `preview`.
 
 
 ## Resources

--- a/iot-hub/Quickstarts/read-d2c-messages/README.md
+++ b/iot-hub/Quickstarts/read-d2c-messages/README.md
@@ -1,0 +1,58 @@
+# Read device-to-cloud messages
+
+This sample demonstrates how to use the Azure Event Hubs client library for .NET to read messages sent from a device by using the built-in Event Hub that exists by default for every IoT Hub instance. 
+
+## Prerequisites
+
+The .NET Core SDK 3.0.0 or greater is recommended.  You can download the .NET Core SDK for multiple platforms from [.NET](https://www.microsoft.com/net/download/all).  You can verify the current version of C# on your development machine using 'dotnet --version'.
+
+This sample can also be compiled using the NET Core SDK 2.1 SDK if the language version of project is changed to `preview`.
+
+## Obtain the Event Hubs-compatible connection string
+
+You can get the Event Hubs-compatible connection string to your IotHub instance via the Azure portal or
+by using the Azure CLI.
+
+If using the Azure portal, see [Built in endpoints for IotHub](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-read-builtin#read-from-the-built-in-endpoint) to get the Event Hubs-compatible connection string and assign it to the variable `connectionString` in the sample. You can skip the Azure CLI instructions in the sample after this.
+
+If using the Azure CLI, you will need to run the below before running this sample to get the details required to form the Event Hubs compatible connection string:
+
+```bash
+az iot hub show --query properties.eventHubEndpoints.events.endpoint --name {your IoT Hub name}
+az iot hub show --query properties.eventHubEndpoints.events.path --name {your IoT Hub name}
+az iot hub policy show --name service --query primaryKey --hub-name {your IoT Hub name}
+```
+
+If you can do neither of the above and need to programmatically get this information, the sample [How to request the IoT Hub built-in Event Hubs-compatible endpoint connection string](https://github.com/Azure/azure-sdk-for-net/blob/master/samples/iothub-connect-to-eventhubs/README.md) demonstrates how to do so.
+
+## WebSocket and proxy support
+
+If you would like to use WebSockts, with our without a proxy, you will need to create a set of options for the [`EventHubConsumerClient`](https://docs.microsoft.com/en-us/dotnet/api/azure.messaging.eventhubs.consumer.eventhubconsumerclient?view=azure-dotnet) to configure its behavior.  Proxy support is offered via the [`IWebProxy`](https://docs.microsoft.com/dotnet/api/system.net.iwebproxy?view=netcore-3.1) interface, which includes the built-in [`WebProxy`](https://docs.microsoft.com/dotnet/api/system.net.webproxy?view=netcore-3.1) class.  Any proxy must be explicitly passed; the client does not assume that any proxy set via the ambient environment or system-wide is desired.
+
+The options may be created as follows:
+
+```csharp
+var options = new EventHubConsumerClientOptions();
+
+// This line sets the transport to use WebSockets.
+options.ConnectionOptions.TransportType = EventHubsTransportType.AmqpWebSockets;
+
+// The following lines configure the options for proxy use.
+IWebProxy proxy = new WebProxy("<< URI TO PROXY >>", true);
+options.ConnectionOptions.Proxy = proxy;
+```
+
+Once you have your options, you'll need to pass them to the client constructor.  Each constructor accepts a set of options as the last parameter, such as:
+
+```csharp
+string consumerGroup = EventHubConsumerClient.DefaultConsumerGroupName;
+await using var consumer = new EventHubConsumerClient(consumerGroup, "<< CONNECTION STRING >>", "<< EVENT HUB >>", options);
+```
+
+## Additional Resources
+
+- [Event Hubs Product Documentation](https://docs.microsoft.com/azure/event-hubs/)
+- [Event Hubs Client Library Documentation](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/eventhub/Azure.Messaging.EventHubs/README.md)
+- [Event Hubs Samples](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/README.md)
+- [Event Processor Client Library Documentation](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/eventhub/Azure.Messaging.EventHubs.Processor/README.md)
+- [Event Processor Samples](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/README.md)

--- a/iot-hub/Quickstarts/read-d2c-messages/ReadDeviceToCloudMessages.cs
+++ b/iot-hub/Quickstarts/read-d2c-messages/ReadDeviceToCloudMessages.cs
@@ -1,101 +1,111 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-// This application uses the Microsoft Azure Event Hubs Client for .NET
-// For samples see: https://github.com/Azure/azure-event-hubs/tree/master/samples/DotNet
-// For documenation see: https://docs.microsoft.com/azure/event-hubs/
+// This application uses the Azure Event Hubs Client for .NET
+// For samples see: https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/README.md
+// For documentation see: https://docs.microsoft.com/azure/event-hubs/
+
 using System;
-using Microsoft.Azure.EventHubs;
-using System.Threading.Tasks;
-using System.Threading;
 using System.Text;
-using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Consumer;
 
 namespace read_d2c_messages
 {
-    class ReadDeviceToCloudMessages
+    public class ReadDeviceToCloudMessages
     {
         // Event Hub-compatible endpoint
         // az iot hub show --query properties.eventHubEndpoints.events.endpoint --name {your IoT Hub name}
-        private readonly static string s_eventHubsCompatibleEndpoint = "{your Event Hubs compatible endpoint}";
+        private const string EventHubsCompatibleEndpoint = "{your Event Hubs compatible endpoint}";
 
         // Event Hub-compatible name
         // az iot hub show --query properties.eventHubEndpoints.events.path --name {your IoT Hub name}
-        private readonly static string s_eventHubsCompatiblePath = "{your Event Hubs compatible name}";
-        
+        private const string EventHubName = "{your Event Hubs compatible name}";
+
         // az iot hub policy show --name service --query primaryKey --hub-name {your IoT Hub name}
-        private readonly static string s_iotHubSasKey = "{your service primary key}";
-        private readonly static string s_iotHubSasKeyName = "service";
-        private static EventHubClient s_eventHubClient;
+        private const string IotHubSasKeyName = "service";
+        private const string IotHubSasKey = "{your service primary key}";
 
-        // Asynchronously create a PartitionReceiver for a partition and then start 
+        // Asynchronously create a PartitionReceiver for a partition and then start
         // reading any messages sent from the simulated client.
-        private static async Task ReceiveMessagesFromDeviceAsync(string partition, CancellationToken ct)
+        private static async Task ReceiveMessagesFromDeviceAsync(CancellationToken cancellationToken)
         {
-            // Create the receiver using the default consumer group.
-            // For the purposes of this sample, read only messages sent since 
-            // the time the receiver is created. Typically, you don't want to skip any messages.
-            var eventHubReceiver = s_eventHubClient.CreateReceiver("$Default", partition, EventPosition.FromEnqueuedTime(DateTime.Now));
-            Console.WriteLine("Create receiver on partition: " + partition);
-            while (true)
+            // If you chose to copy the "Event Hub-compatible endpoint" from the "Built-in endpoints" section
+            // of your IoT Hub instance in the Azure portal, you can set the connection string to that value
+            // directly and remove the call to "BuildEventHubsConnectionString".
+            string connectionString = BuildEventHubsConnectionString(EventHubsCompatibleEndpoint, IotHubSasKeyName, IotHubSasKey);
+
+            // Create the consumer using the default consumer group using a direct connection to the service.
+            // Information on using the client with a proxy can be found in the README for this quick start, here:
+            //   https://github.com/Azure-Samples/azure-iot-samples-csharp/tree/master/iot-hub/Quickstarts/read-d2c-messages/README.md#websocket-and-proxy-support
+            //
+            await using EventHubConsumerClient consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString, EventHubName);
+
+            Console.WriteLine("Listening for messages on all partitions");
+
+            try
             {
-                if (ct.IsCancellationRequested) break;
-                Console.WriteLine("Listening for messages on: " + partition);
-                // Check for EventData - this methods times out if there is nothing to retrieve.
-                var events = await eventHubReceiver.ReceiveAsync(100);
+                // Begin reading events for all partitions, starting with the first event in each partition and waiting indefinitely for
+                // events to become available.  Reading can be canceled by breaking out of the loop when an event is processed or by
+                // signaling the cancellation token.
+                //
+                // The "ReadEventsAsync" method on the consumer is a good starting point for consuming events for prototypes
+                // and samples.  For real-world production scenarios, it is strongly recommended that you consider using the
+                // "EventProcessorClient" from the "Azure.Messaging.EventHubs.Processor" package.
+                //
+                // More information on the "EventProcessorClient" and its benefits can be found here:
+                //   https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs.Processor/README.md
+                //
+                await foreach (PartitionEvent partitionEvent in consumer.ReadEventsAsync(cancellationToken))
+                {
+                    Console.WriteLine("Message received on partition {0}:", partitionEvent.Partition.PartitionId);
 
-                // If there is data in the batch, process it.
-                if (events == null) continue;
+                    string data = Encoding.UTF8.GetString(partitionEvent.Data.Body.ToArray());
+                    Console.WriteLine("\t{0}:", data);
 
-                foreach(EventData eventData in events)
-                { 
-                  string data = Encoding.UTF8.GetString(eventData.Body.Array);
-                  Console.WriteLine("Message received on partition {0}:", partition);
-                  Console.WriteLine("  {0}:", data);
-                  Console.WriteLine("Application properties (set by device):");
-                  foreach (var prop in eventData.Properties)
-                  {
-                    Console.WriteLine("  {0}: {1}", prop.Key, prop.Value);
-                  }
-                  Console.WriteLine("System properties (set by IoT Hub):");
-                  foreach (var prop in eventData.SystemProperties)
-                  {
-                    Console.WriteLine("  {0}: {1}", prop.Key, prop.Value);
-                  }
+                    Console.WriteLine("Application properties (set by device):");
+                    foreach (var prop in partitionEvent.Data.Properties)
+                    {
+                        Console.WriteLine("\t{0}: {1}", prop.Key, prop.Value);
+                    }
+
+                    Console.WriteLine("System properties (set by IoT Hub):");
+                    foreach (var prop in partitionEvent.Data.SystemProperties)
+                    {
+                        Console.WriteLine("\t{0}: {1}", prop.Key, prop.Value);
+                    }
                 }
             }
+            catch (TaskCanceledException)
+            {
+                // This is expected when the token is signaled; it should not be considered an
+                // error in this scenario.
+            }
         }
 
-        private static async Task Main(string[] args)
+        public static async Task Main(string[] args)
         {
             Console.WriteLine("IoT Hub Quickstarts - Read device to cloud messages. Ctrl-C to exit.\n");
+            using var cancellationSource = new CancellationTokenSource();
 
-            // Create an EventHubClient instance to connect to the
-            // IoT Hub Event Hubs-compatible endpoint.
-            var connectionString = new EventHubsConnectionStringBuilder(new Uri(s_eventHubsCompatibleEndpoint), s_eventHubsCompatiblePath, s_iotHubSasKeyName, s_iotHubSasKey);
-            s_eventHubClient = EventHubClient.CreateFromConnectionString(connectionString.ToString());
-
-            // Create a PartitionReciever for each partition on the hub.
-            var runtimeInfo = await s_eventHubClient.GetRuntimeInformationAsync();
-            var d2cPartitions = runtimeInfo.PartitionIds;
-
-            CancellationTokenSource cts = new CancellationTokenSource();
-
-            Console.CancelKeyPress += (s, e) =>
+            void cancelKeyPressHandler(object sender, ConsoleCancelEventArgs eventArgs)
             {
-                e.Cancel = true;
-                cts.Cancel();
+                eventArgs.Cancel = true;
+                cancellationSource.Cancel();
                 Console.WriteLine("Exiting...");
-            };
 
-            var tasks = new List<Task>();
-            foreach (string partition in d2cPartitions)
-            {
-                tasks.Add(ReceiveMessagesFromDeviceAsync(partition, cts.Token));
+                Console.CancelKeyPress -= cancelKeyPressHandler;
             }
 
-            // Wait for all the PartitionReceivers to finsih.
-            Task.WaitAll(tasks.ToArray());
+            Console.CancelKeyPress += cancelKeyPressHandler;
+            await ReceiveMessagesFromDeviceAsync(cancellationSource.Token);
         }
+
+        private static string BuildEventHubsConnectionString(string eventHubsEndpoint,
+                                                             string iotHubSharedKeyName,
+                                                             string iotHubSharedKey) =>
+            $"Endpoint={ eventHubsEndpoint };SharedAccessKeyName={ iotHubSharedKeyName };SharedAccessKey={ iotHubSharedKey }";
+
     }
 }

--- a/iot-hub/Quickstarts/read-d2c-messages/read-d2c-messages.csproj
+++ b/iot-hub/Quickstarts/read-d2c-messages/read-d2c-messages.csproj
@@ -1,13 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <LangVersion>7.1</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.EventHubs" Version="2.*" />
+    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Purpose

The focus of these changes is to update the version of the Event Hubs client library in use for the sample, moving to the new `Azure.Messaging.EventHubs` package and enhancing the documentation which accompanies it.

## Does this introduce a breaking change?

- [x] Yes
- [ ] No


## Pull Request Type
What kind of change does this Pull Request introduce?

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Documentation content changes
- [x] Other... Please describe: `Dependency update`

## How to Test

### Obtain the code
```
git clone git@github.com:jsquire/azure-iot-samples-csharp.git ./squire-samples
cd squire-samples
git checkout sample/d2c-update
dotnet restore
dotnet build
```

### Run the sample
```
- Add your event hub compatible endpoint information by running Azure CLI
- Update the code in `<root>`\iot-hub\Quickstarts\read-d2c-messages\ReadDeviceToCloudMessages.cs`. 
- Send data to your IotHub via any means you are familiar with
- Run the `read-d2c-messages` project and observe the console window
```

## What to Check
Verify that the following are valid
```
- Verify that the sample prints out messages that you have sent
```