### PR TITLE
fix(samples): Fixing the cleanup script to be case insensitive like A…

### DIFF
--- a/iot-hub/Samples/service/CleanUpDevicesSample/CleanUpDevicesSample.cs
+++ b/iot-hub/Samples/service/CleanUpDevicesSample/CleanUpDevicesSample.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Azure.Devices.Samples
                     string deviceId = twinResult.DeviceId;
                     foreach (string prefix in _deleteDeviceWithPrefix)
                     {
-                        if (deviceId.StartsWith(prefix))
+                        if (deviceId.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
                         {
                             _devicesToDelete.Add(new Device(deviceId));
                         }

--- a/provisioning/Samples/service/CleanupEnrollmentsSample/CleanupEnrollmentsSample.cs
+++ b/provisioning/Samples/service/CleanupEnrollmentsSample/CleanupEnrollmentsSample.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Samples
                     List<IndividualEnrollment> individualEnrollments = new List<IndividualEnrollment>();
                     foreach (IndividualEnrollment enrollment in items)
                     {
-                        if (!individualEnrollmentsToBeRetained.Contains(enrollment.RegistrationId))
+                        if (!individualEnrollmentsToBeRetained.Contains(enrollment.RegistrationId, StringComparer.OrdinalIgnoreCase))
                         {
                             individualEnrollments.Add(enrollment);
                             Console.WriteLine($"Individual Enrollment to be deleted: {enrollment.RegistrationId}");
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Service.Samples
                     var items = queryResult.Items;
                     foreach (EnrollmentGroup enrollment in items)
                     {
-                        if (!groupEnrollmentsToBeRetained.Contains(enrollment.EnrollmentGroupId))
+                        if (!groupEnrollmentsToBeRetained.Contains(enrollment.EnrollmentGroupId, StringComparer.OrdinalIgnoreCase))
                         {
                             Console.WriteLine($"EnrollmentGroup to be deleted: {enrollment.EnrollmentGroupId}");
                             _enrollmentGroupsDeleted++;


### PR DESCRIPTION
These azure resources are case-insensitive and were getting removed unintentionally by the script if they were created with a different casing.