### PR TITLE
Update NuGet dependencies to point to GA packages

### DIFF
--- a/iot-hub/Samples/device/PnpDeviceSamples/PnpConvention/PnpHelpers.csproj
+++ b/iot-hub/Samples/device/PnpDeviceSamples/PnpConvention/PnpHelpers.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.31.0-pnp-preview" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.31.0" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />

--- a/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController/TemperatureController.csproj
+++ b/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController/TemperatureController.csproj
@@ -8,9 +8,9 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.31.0-pnp-preview" />
-    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Client" Version="1.7.0-pnp-preview" />
-    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Transport.Mqtt" Version="1.4.0-pnp-preview" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.31.0" />
+    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Client" Version="1.16.0" />
+    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Transport.Mqtt" Version="1.13.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.8" />
   </ItemGroup>
 

--- a/iot-hub/Samples/device/PnpDeviceSamples/Thermostat/Thermostat.csproj
+++ b/iot-hub/Samples/device/PnpDeviceSamples/Thermostat/Thermostat.csproj
@@ -8,9 +8,9 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.31.0-pnp-preview" />
-    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Client" Version="1.7.0-pnp-preview" />
-    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Transport.Mqtt" Version="1.4.0-pnp-preview" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.31.0" />
+    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Client" Version="1.16.0" />
+    <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Transport.Mqtt" Version="1.13.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.8" />
   </ItemGroup>
 </Project>

--- a/iot-hub/Samples/service/DigitalTwinClientSamples/TemperatureController/TemperatureController.csproj
+++ b/iot-hub/Samples/service/DigitalTwinClientSamples/TemperatureController/TemperatureController.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.23.0-pnp-preview-001" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.27.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.8" />
   </ItemGroup>
 

--- a/iot-hub/Samples/service/DigitalTwinClientSamples/TemperatureController/TemperatureControllerSample.cs
+++ b/iot-hub/Samples/service/DigitalTwinClientSamples/TemperatureController/TemperatureControllerSample.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.Devices.Samples
         private const string Thermostat1Component = "thermostat1";
 
         private static readonly string DeviceSampleLink = 
-            "https://github.com/Azure-Samples/azure-iot-samples-csharp/tree/feature/digitaltwin/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController";
+            "https://github.com/Azure-Samples/azure-iot-samples-csharp/tree/master/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController";
 
         private static readonly Random Random = new Random();
         private readonly DigitalTwinClient _digitalTwinClient;

--- a/iot-hub/Samples/service/DigitalTwinClientSamples/Thermostat/Thermostat.csproj
+++ b/iot-hub/Samples/service/DigitalTwinClientSamples/Thermostat/Thermostat.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.23.0-pnp-preview-001" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.27.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.8" />
   </ItemGroup>
 </Project>

--- a/iot-hub/Samples/service/DigitalTwinClientSamples/Thermostat/ThermostatSample.cs
+++ b/iot-hub/Samples/service/DigitalTwinClientSamples/Thermostat/ThermostatSample.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Azure.Devices.Samples
                 {
                     _logger.LogWarning($"Unable to execute command {getMaxMinReportCommandName} on {_digitalTwinId}." +
                         $"\nMake sure that the device sample Thermostat located in " +
-                        $"https://github.com/Azure-Samples/azure-iot-samples-csharp/tree/feature/digitaltwin/iot-hub/Samples/device/PnpDeviceSamples/Thermostat " +
+                        $"https://github.com/Azure-Samples/azure-iot-samples-csharp/tree/master/iot-hub/Samples/device/PnpDeviceSamples/Thermostat " +
                         $"is also running.");
                 }
             }

--- a/iot-hub/Samples/service/PnpServiceSamples/TemperatureController/TemperatureController.csproj
+++ b/iot-hub/Samples/service/PnpServiceSamples/TemperatureController/TemperatureController.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.23.0-pnp-preview-001" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.27.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.5" />
   </ItemGroup>
 </Project>

--- a/iot-hub/Samples/service/PnpServiceSamples/TemperatureController/TemperatureControllerSample.cs
+++ b/iot-hub/Samples/service/PnpServiceSamples/TemperatureController/TemperatureControllerSample.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.Devices.Samples
 
         private static readonly Random Random = new Random();
         private static readonly string DeviceSampleLink =
-            "https://github.com/Azure-Samples/azure-iot-samples-csharp/tree/feature/digitaltwin/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController";
+            "https://github.com/Azure-Samples/azure-iot-samples-csharp/tree/master/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController";
 
         private readonly ServiceClient _serviceClient;
         private readonly RegistryManager _registryManager;

--- a/iot-hub/Samples/service/PnpServiceSamples/Thermostat/Thermostat.csproj
+++ b/iot-hub/Samples/service/PnpServiceSamples/Thermostat/Thermostat.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.23.0-pnp-preview-001" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.27.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.5" />
   </ItemGroup>
 </Project>

--- a/iot-hub/Samples/service/PnpServiceSamples/Thermostat/ThermostatSample.cs
+++ b/iot-hub/Samples/service/PnpServiceSamples/Thermostat/ThermostatSample.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.Devices.Samples
             {
                 _logger.LogWarning($"Unable to execute command {getMaxMinReportCommandName} on {_digitalTwinId}." +
                     $"\nMake sure that the device sample Thermostat located in " +
-                    $"https://github.com/Azure-Samples/azure-iot-samples-csharp/tree/feature/digitaltwin/iot-hub/Samples/device/PnpDeviceSamples/Thermostat " +
+                    $"https://github.com/Azure-Samples/azure-iot-samples-csharp/tree/master/iot-hub/Samples/device/PnpDeviceSamples/Thermostat " +
                     $"is also running.");
             }
         }


### PR DESCRIPTION
This PR is for preparation for PnP samples to go GA. These changes will not be checked in to master until the GA packages have been published on NuGet.org