### PR TITLE
More changes to helpers, writable property response

### DIFF
--- a/iot-hub/Samples/device/PnpDeviceSamples/PnpConvention/PnpConventionTests.cs
+++ b/iot-hub/Samples/device/PnpDeviceSamples/PnpConvention/PnpConventionTests.cs
@@ -1,4 +1,8 @@
-﻿using FluentAssertions;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using Microsoft.Azure.Devices.Shared;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -25,8 +29,8 @@ namespace PnpHelpers
                 const string propertyName = "someName";
                 const int propertyValue = 10;
 
-                string patch = PnpConvention.CreatePropertyPatch(propertyName, propertyValue);
-                var jObject = JObject.Parse(patch);
+                TwinCollection patch = PnpConvention.CreatePropertyPatch(propertyName, propertyValue);
+                var jObject = JObject.Parse(patch.ToJson());
 
                 jObject.Count.Should().Be(1, "there should be a single property added");
                 jObject.Value<int>(propertyName).Should().Be(propertyValue);
@@ -47,9 +51,9 @@ namespace PnpHelpers
                 const string propertyName = "someName";
                 const int propertyValue = 10;
 
-                string patch = PnpConvention.CreateComponentPropertyPatch(componentName, propertyName, propertyValue);
+                TwinCollection patch = PnpConvention.CreateComponentPropertyPatch(componentName, propertyName, propertyValue);
 
-                var jObject = JObject.Parse(patch);
+                var jObject = JObject.Parse(patch.ToJson());
                 JObject component = jObject.Value<JObject>(componentName);
 
                 component.Count.Should().Be(2, "there should be two properties added - the above property and a component identifier {\"__t\": \"c\"}");
@@ -76,9 +80,9 @@ namespace PnpHelpers
                 const int ackCode = 200;
                 const long ackVersion = 2;
 
-                string patch = PnpConvention.CreatePropertyEmbeddedValuePatch(propertyName, propertyValue, ackCode, ackVersion);
+                TwinCollection patch = PnpConvention.CreateWritablePropertyResponse(propertyName, propertyValue, ackCode, ackVersion);
 
-                var jObject = JObject.Parse(patch);
+                var jObject = JObject.Parse(patch.ToJson());
                 EmbeddedPropertyPatch actualPatch = jObject.ToObject<EmbeddedPropertyPatch>();
 
                 // The property patch object should have "value", "ac" and "av" properties set. Since we did not supply an "ackDescription", "ad" should be null.
@@ -111,15 +115,15 @@ namespace PnpHelpers
                 const long ackVersion = 2;
                 const string ackDescription = "The update was successful";
 
-                string patch = PnpConvention.CreatePropertyEmbeddedValuePatch(
+                TwinCollection patch = PnpConvention.CreateComponentWritablePropertyResponse(
+                    componentName,
                     propertyName,
                     JsonConvert.SerializeObject(propertyValue),
                     ackCode,
                     ackVersion,
-                    ackDescription,
-                    componentName);
+                    ackDescription);
 
-                var jObject = JObject.Parse(patch);
+                var jObject = JObject.Parse(patch.ToJson());
                 JObject component = jObject.Value<JObject>(componentName);
 
                 // There should be two properties added to the component- the above property and a component identifier "__t": "c".

--- a/iot-hub/Samples/device/PnpDeviceSamples/PnpConvention/WritablePropertyResponse.cs
+++ b/iot-hub/Samples/device/PnpDeviceSamples/PnpConvention/WritablePropertyResponse.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Newtonsoft.Json;
+
+namespace PnpHelpers
+{
+    /// <summary>
+    /// The payload for a property update response.
+    /// </summary>
+    public class WritablePropertyResponse
+    {
+        /// <summary>
+        /// Empty constructor.
+        /// </summary>
+        public WritablePropertyResponse() { }
+
+        /// <summary>
+        /// Convenience constructor for specifying the properties.
+        /// </summary>
+        /// <param name="propertyValue">The unserialized property value.</param>
+        /// <param name="ackCode">The acknowledgement code, usually an HTTP Status Code e.g. 200, 400.</param>
+        /// <param name="ackVersion">The acknowledgement version, as supplied in the property update request.</param>
+        /// <param name="ackDescription">The acknowledgement description, an optional, human-readable message about the result of the property update.</param>
+        public WritablePropertyResponse(object propertyValue, int ackCode, long ackVersion, string ackDescription = null)
+        {
+            PropertyValue = propertyValue;
+            AckCode = ackCode;
+            AckVersion = ackVersion;
+            AckDescription = ackDescription;
+        }
+
+        /// <summary>
+        /// The unserialized property value.
+        /// </summary>
+        [JsonProperty("value")]
+        public object PropertyValue { get; set; }
+
+        /// <summary>
+        /// The acknowledgement code, usually an HTTP Status Code e.g. 200, 400.
+        /// </summary>
+        [JsonProperty("ac")]
+        public int AckCode { get; set; }
+
+        /// <summary>
+        /// The acknowledgement version, as supplied in the property update request.
+        /// </summary>
+        [JsonProperty("av")]
+        public long AckVersion { get; set; }
+
+        /// <summary>
+        /// The acknowledgement description, an optional, human-readable message about the result of the property update.
+        /// </summary>
+        [JsonProperty("ad", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string AckDescription { get; set; }
+    }
+}


### PR DESCRIPTION
Give single and batch options for reporting property write requests. Use a JSON serialization library to create the response.