### PR TITLE
Add lunchSettings with EnvVars predefined

### DIFF
--- a/iot-hub/Samples/device/PnpDeviceSamples/.vscode/launch.json
+++ b/iot-hub/Samples/device/PnpDeviceSamples/.vscode/launch.json
@@ -1,0 +1,74 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Thermostat-Hub",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "buildThermostat",
+            "program": "${workspaceFolder}/Thermostat/bin/Debug/netcoreapp3.1/Thermostat.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/Thermostat",
+            "console": "internalConsole",
+            "stopAtEntry": false,
+            "env": {
+                "IOTHUB_DEVICE_SECURITY_TYPE": "connectionString",
+                "IOTHUB_DEVICE_CONNECTION_STRING": ""
+            }
+        },
+        {
+            "name": "Thermostat-DPS",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "buildThermostat",
+            "program": "${workspaceFolder}/Thermostat/bin/Debug/netcoreapp3.1/Thermostat.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/Thermostat",
+            "console": "internalConsole",
+            "stopAtEntry": false,
+            "env": {
+                "IOTHUB_DEVICE_SECURITY_TYPE": "dps",
+                "IOTHUB_DEVICE_DPS_ID_SCOPE": "",
+                "IOTHUB_DEVICE_DPS_DEVICE_ID": "",
+                "IOTHUB_DEVICE_DPS_DEVICE_KEY": "",
+                "IOTHUB_DEVICE_DPS_ENDPOINT": "global.azure-devices-provisioning.net"
+            }
+        },
+        {
+            "name": "TempCtrlr-Hub",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "buildTempCtrlr",
+            "program": "${workspaceFolder}/TemperatureController/bin/Debug/netcoreapp3.1/TemperatureController.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/TemperatureController",
+            "console": "internalConsole",
+            "stopAtEntry": false,
+            "env": {
+                "IOTHUB_DEVICE_SECURITY_TYPE": "connectionString",
+                "IOTHUB_DEVICE_CONNECTION_STRING": ""
+            }
+        },
+        {
+            "name": "TempCtrlr-DPS",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "buildTempCtrlr",
+            "program": "${workspaceFolder}/TemperatureController/bin/Debug/netcoreapp3.1/TemperatureController.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/TemperatureController",
+            "console": "internalConsole",
+            "stopAtEntry": false,
+            "env": {
+                "IOTHUB_DEVICE_SECURITY_TYPE": "dps",
+                "IOTHUB_DEVICE_DPS_ID_SCOPE": "",
+                "IOTHUB_DEVICE_DPS_DEVICE_ID": "",
+                "IOTHUB_DEVICE_DPS_DEVICE_KEY": "",
+                "IOTHUB_DEVICE_DPS_ENDPOINT": "global.azure-devices-provisioning.net"
+            }
+        }
+    ]
+}

--- a/iot-hub/Samples/device/PnpDeviceSamples/.vscode/tasks.json
+++ b/iot-hub/Samples/device/PnpDeviceSamples/.vscode/tasks.json
@@ -1,0 +1,43 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "buildThermostat",
+            "command": "dotnet",
+            "type": "shell",
+            "args": [
+                "build",
+                "Thermostat",
+                // Ask dotnet build to generate full paths for file names.
+                "/property:GenerateFullPaths=true",
+                // Do not generate summary otherwise it leads to duplicate errors in Problems panel
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "group": "build",
+            "presentation": {
+                "reveal": "silent"
+            },
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "buildTempCtrlr",
+            "command": "dotnet",
+            "type": "shell",
+            "args": [
+                "build",
+                "TemperatureController",
+                // Ask dotnet build to generate full paths for file names.
+                "/property:GenerateFullPaths=true",
+                // Do not generate summary otherwise it leads to duplicate errors in Problems panel
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "group": "build",
+            "presentation": {
+                "reveal": "silent"
+            },
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController/Properties/launchSettings.json
+++ b/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController/Properties/launchSettings.json
@@ -1,0 +1,22 @@
+{
+  "profiles": {
+    "Hub": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "IOTHUB_DEVICE_SECURITY_TYPE": "connectionString",
+        "IOTHUB_DEVICE_CONNECTION_STRING": ""
+      }
+    },
+    "DPS": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "IOTHUB_DEVICE_SECURITY_TYPE": "dps",
+        "IOTHUB_DEVICE_DPS_ID_SCOPE": "",
+        "IOTHUB_DEVICE_DPS_DEVICE_ID": "",
+        "IOTHUB_DEVICE_DPS_DEVICE_KEY": "",
+        "IOTHUB_DEVICE_DPS_ENDPOINT": "global.azure-devices-provisioning.net"
+      },
+      "sqlDebugging": false
+    }
+  }
+}

--- a/iot-hub/Samples/device/PnpDeviceSamples/Thermostat/Properties/launchSettings.json
+++ b/iot-hub/Samples/device/PnpDeviceSamples/Thermostat/Properties/launchSettings.json
@@ -1,0 +1,22 @@
+{
+  "profiles": {
+    "Hub": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "IOTHUB_DEVICE_SECURITY_TYPE": "connectionString",
+        "IOTHUB_DEVICE_CONNECTION_STRING": ""
+      }
+    },
+    "DPS": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "IOTHUB_DEVICE_SECURITY_TYPE": "dps",
+        "IOTHUB_DEVICE_DPS_ID_SCOPE": "",
+        "IOTHUB_DEVICE_DPS_DEVICE_ID": "",
+        "IOTHUB_DEVICE_DPS_DEVICE_KEY": "",
+        "IOTHUB_DEVICE_DPS_ENDPOINT": "global.azure-devices-provisioning.net"
+      },
+      "sqlDebugging": false
+    }
+  }
+}

--- a/iot-hub/Samples/service/PnpServiceSamples/.vscode/launch.json
+++ b/iot-hub/Samples/service/PnpServiceSamples/.vscode/launch.json
@@ -1,0 +1,44 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "TemperatureController",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "buildTemperatureController",
+            "program": "${workspaceFolder}/TemperatureController/bin/Debug/netcoreapp3.1/TemperatureController.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/TemperatureController",
+            "console": "internalConsole",
+            "stopAtEntry": false,
+            "env" :{
+                "IOTHUB_CONNECTION_STRING": "",
+                "IOTHUB_DEVICE_ID": ""
+            }
+        },
+        {
+            "name": "Thermostat",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "buildThermostat",
+            "program": "${workspaceFolder}/Thermostat/bin/Debug/netcoreapp3.1/Thermostat.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/Thermostat",
+            "console": "internalConsole",
+            "stopAtEntry": false,
+            "env" :{
+                "IOTHUB_CONNECTION_STRING": "",
+                "IOTHUB_DEVICE_ID": ""
+            }
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        }
+    ]
+}

--- a/iot-hub/Samples/service/PnpServiceSamples/.vscode/tasks.json
+++ b/iot-hub/Samples/service/PnpServiceSamples/.vscode/tasks.json
@@ -1,0 +1,54 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "buildTemperatureController",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/TemperatureController/TemperatureController.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "buildThermostat",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/Thermostat/Thermostat.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/TemperatureController/TemperatureController.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "${workspaceFolder}/TemperatureController/TemperatureController.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/iot-hub/Samples/service/PnpServiceSamples/TemperatureController/Properties/launchSettings.json
+++ b/iot-hub/Samples/service/PnpServiceSamples/TemperatureController/Properties/launchSettings.json
@@ -1,0 +1,11 @@
+{
+  "profiles": {
+    "TemperatureController": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "IOTHUB_CONNECTION_STRING": "",
+        "IOTHUB_DEVICE_ID": ""
+      }
+    }
+  }
+}

--- a/iot-hub/Samples/service/PnpServiceSamples/Thermostat/Properties/launchSettings.json
+++ b/iot-hub/Samples/service/PnpServiceSamples/Thermostat/Properties/launchSettings.json
@@ -1,0 +1,11 @@
+{
+  "profiles": {
+    "TemperatureController": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "IOTHUB_CONNECTION_STRING": "",
+        "IOTHUB_DEVICE_ID": ""
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Purpose

The PnP Samples require some environment variables to work.
This PR includes lunchSettings for VS and VSCode with the variable names already pre-configured.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe:
```

## How to Test
*  Get the code

![image](https://user-images.githubusercontent.com/14916339/94983361-d6f86100-04f6-11eb-8468-a5e3e2eb9e90.png)

![image](https://user-images.githubusercontent.com/14916339/94983363-de1f6f00-04f6-11eb-90c3-d4170eeb0859.png)
