### PR TITLE
change tempcontroller sample to v2 model

### DIFF
--- a/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController/Models/TemperatureController.json
+++ b/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController/Models/TemperatureController.json
@@ -1,58 +1,83 @@
 {
-  "@context": "dtmi:dtdl:context;2",
-  "@id": "dtmi:com:example:TemperatureController;1",
-  "@type": "Interface",
-  "displayName": "Temperature Controller",
-  "description": "Device with two thermostats and remote reboot.",
-  "contents": [    {
-      "@type": [
-        "Telemetry", "DataSize"
-      ],
-      "name": "workingSet",
-      "displayName": "Working Set",
-      "description": "Current working set of the device memory in KiB.",
-      "schema": "double",
-      "unit" : "kibibyte"
-    },
-    {
-      "@type": "Property",
-      "name": "serialNumber",
-      "displayName": "Serial Number",
-      "description": "Serial number of the device.",
-      "schema": "string"
-    },
-    {
-      "@type": "Command",
-      "name": "reboot",
-      "displayName": "Reboot",
-      "description": "Reboots the device after waiting the number of seconds specified.",
-      "request": {
-        "name": "delay",
-        "displayName": "Delay",
-        "description": "Number of seconds to wait before rebooting the device.",
-        "schema": "integer"
+    "@context": [
+      "dtmi:iotcentral:context;2",
+      "dtmi:dtdl:context;2"
+    ],
+    "@id": "dtmi:com:example:TemperatureController;2",
+    "@type": "Interface",
+    "contents": [
+      {
+        "@type": [
+          "Telemetry",
+          "DataSize"
+        ],
+        "description": {
+          "en": "Current working set of the device memory in KiB."
+        },
+        "displayName": {
+          "en": "Working Set"
+        },
+        "name": "workingSet",
+        "schema": "double",
+        "unit": "kibibit"
+      },
+      {
+        "@type": "Property",
+        "displayName": {
+          "en": "Serial Number"
+        },
+        "name": "serialNumber",
+        "schema": "string",
+        "writable": false
+      },
+      {
+        "@type": "Command",
+        "commandType": "synchronous",
+        "description": {
+          "en": "Reboots the device after waiting the number of seconds specified."
+        },
+        "displayName": {
+          "en": "Reboot"
+        },
+        "name": "reboot",
+        "request": {
+          "@type": "CommandPayload",
+          "description": {
+            "en": "Number of seconds to wait before rebooting the device."
+          },
+          "displayName": {
+            "en": "Delay"
+          },
+          "name": "delay",
+          "schema": "integer"
+        }
+      },
+      {
+        "@type": "Component",
+        "displayName": {
+          "en": "thermostat1"
+        },
+        "name": "thermostat1",
+        "schema": "dtmi:com:example:Thermostat;1"
+      },
+      {
+        "@type": "Component",
+        "displayName": {
+          "en": "thermostat2"
+        },
+        "name": "thermostat2",
+        "schema": "dtmi:com:example:Thermostat;2"
+      },
+      {
+        "@type": "Component",
+        "displayName": {
+          "en": "DeviceInfo"
+        },
+        "name": "deviceInformation",
+        "schema": "dtmi:azure:DeviceManagement:DeviceInformation;1"
       }
-    },
-    {
-      "@type" : "Component",
-      "schema": "dtmi:com:example:Thermostat;1",
-      "name": "thermostat1",
-      "displayName": "Thermostat One",
-      "description": "Thermostat One of Two."
-    },
-    {
-      "@type" : "Component",
-      "schema": "dtmi:com:example:Thermostat;1",
-      "name": "thermostat2",
-      "displayName": "Thermostat Two",
-      "description": "Thermostat Two of Two."
-    },
-    {
-      "@type": "Component",
-      "schema": "dtmi:azure:DeviceManagement:DeviceInformation;1",
-      "name": "deviceInformation",
-      "displayName": "Device Information interface",
-      "description": "Optional interface with basic device hardware information."
+    ],
+    "displayName": {
+      "en": "Temperature Controller"
     }
-  ]
-}
+  }

--- a/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController/Models/Thermostat2.json
+++ b/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController/Models/Thermostat2.json
@@ -1,0 +1,89 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:com:example:Thermostat;2",
+  "@type": "Interface",
+  "displayName": "Thermostat",
+  "description": "Reports current temperature and provides desired temperature control.",
+  "contents": [
+    {
+      "@type": [
+        "Telemetry",
+        "Temperature"
+      ],
+      "name": "temperature",
+      "displayName" : "Temperature",
+      "description" : "Temperature in degrees Celsius.",
+      "schema": "double",
+      "unit": "degreeCelsius"
+    },
+    {
+      "@type": [
+        "Property",
+        "Temperature"
+      ],
+      "name": "targetTemperature",
+      "schema": "double",
+      "displayName": "Target Temperature",
+      "description": "Allows to remotely specify the desired target temperature.",
+      "unit" : "degreeCelsius",
+      "writable": true
+    },
+    {
+      "@type": [
+        "Property",
+        "Temperature"
+      ],
+      "name": "maxTempSinceLastReboot",
+      "schema": "double",
+      "unit" : "degreeCelsius",
+      "displayName": "Max temperature since last reboot.",
+      "description": "Returns the max temperature since last device reboot."
+    },
+    {
+      "@type": "Command",
+      "name": "getMaxMinReport",
+      "displayName": "Get Max-Min report.",
+      "description": "This command returns the max, min and average temperature from the specified time to the current time.",
+      "request": {
+        "name": "since",
+        "displayName": "Since",
+        "description": "Period to return the max-min report.",
+        "schema": "dateTime"
+      },
+      "response": {
+        "name" : "tempReport",
+        "displayName": "Temperature Report",
+        "schema": {
+          "@type": "Object",
+          "fields": [
+            {
+              "name": "maxTemp",
+              "displayName": "Max temperature",
+              "schema": "double"
+            },
+            {
+              "name": "minTemp",
+              "displayName": "Min temperature",
+              "schema": "double"
+            },
+            {
+              "name" : "avgTemp",
+              "displayName": "Average Temperature",
+              "schema": "double"
+            },
+            {
+              "name" : "startTime",
+              "displayName": "Start Time",
+              "schema": "dateTime"
+            },
+            {
+              "name" : "endTime",
+              "displayName": "End Time",
+              "schema": "dateTime"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController/Program.cs
+++ b/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController/Program.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
     public class Program
     {
         // DTDL interface used: https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/samples/TemperatureController.json
-        private const string ModelId = "dtmi:com:example:TemperatureController;1";
+        private const string ModelId = "dtmi:com:example:TemperatureController;2";
 
         private static ILogger s_logger;
 

--- a/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController/Program.cs
+++ b/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController/Program.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
 {
     public class Program
     {
-        // DTDL interface used: https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/samples/TemperatureController.json
+        // DTDL interface used: https://github.com/Azure/iot-plugandplay-models
         private const string ModelId = "dtmi:com:example:TemperatureController;2";
 
         private static ILogger s_logger;

--- a/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController/Program.cs
+++ b/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController/Program.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Azure.Devices.Client.Samples
     public class Program
     {
         // DTDL interface used: https://github.com/Azure/iot-plugandplay-models
+        // in v2 of TempController Model, we use 2 different model of Thermostat, 
+        // in fact 2 different version of the same interface, to Allow IoT Central Handling correctly this model
         private const string ModelId = "dtmi:com:example:TemperatureController;2";
 
         private static ILogger s_logger;

--- a/iot-hub/Samples/device/PnpDeviceSamples/Thermostat/Program.cs
+++ b/iot-hub/Samples/device/PnpDeviceSamples/Thermostat/Program.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
 {
     public class Program
     {
-        // DTDL interface used: https://github.com/Azure/iot-plugandplay-models
+        // DTDL interface used: https://github.com/Azure/iot-plugandplay-models/blob/main/dtmi/com/example/temperaturecontroller-2.json
         private const string ModelId = "dtmi:com:example:Thermostat;1";
 
         private static ILogger s_logger;

--- a/iot-hub/Samples/device/PnpDeviceSamples/Thermostat/Program.cs
+++ b/iot-hub/Samples/device/PnpDeviceSamples/Thermostat/Program.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
 {
     public class Program
     {
-        // DTDL interface used: https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/samples/Thermostat.json
+        // DTDL interface used: https://github.com/Azure/iot-plugandplay-models
         private const string ModelId = "dtmi:com:example:Thermostat;1";
 
         private static ILogger s_logger;


### PR DESCRIPTION
## Purpose
Make this sample compatible with IoT Central
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[X] No
```

## Pull Request Type
Make this sample compatible with IoT Central

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Run the sample as usual, it now use the v2:
private const string ModelId = "dtmi:com:example:TemperatureController;2";
