### PR TITLE
Fix QuickStart samples build

### DIFF
--- a/iot-hub/Quickstarts/device-streams-proxy/device/DeviceLocalProxyStreamingSample.csproj
+++ b/iot-hub/Quickstarts/device-streams-proxy/device/DeviceLocalProxyStreamingSample.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-	<PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.29.0-preview-*" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.32.0-preview-001" />
   </ItemGroup>
-  
+
 </Project>

--- a/iot-hub/Quickstarts/device-streams-proxy/device/DeviceStreamSample.cs
+++ b/iot-hub/Quickstarts/device-streams-proxy/device/DeviceStreamSample.cs
@@ -14,11 +14,11 @@ namespace Microsoft.Azure.Devices.Client.Samples
 {
     public class DeviceStreamSample
     {
-        private DeviceClient _deviceClient;
-        private String _host;
-        private int _port;
+        private readonly DeviceClient _deviceClient;
+        private readonly string _host;
+        private readonly int _port;
 
-        public DeviceStreamSample(DeviceClient deviceClient, String host, int port)
+        public DeviceStreamSample(DeviceClient deviceClient, string host, int port)
         {
             _deviceClient = deviceClient;
             _host = host;
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
             while (localStream.CanRead)
             {
                 int receiveCount = await localStream.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false);
-                    
+
                 await remoteStream.SendAsync(new ArraySegment<byte>(buffer, 0, receiveCount), WebSocketMessageType.Binary, true, cancellationToken).ConfigureAwait(false);
             }
         }
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
                 {
                     await _deviceClient.AcceptDeviceStreamRequestAsync(streamRequest, cancellationTokenSource.Token).ConfigureAwait(false);
 
-                    using (ClientWebSocket webSocket = await DeviceStreamingCommon.GetStreamingClientAsync(streamRequest.Url, streamRequest.AuthorizationToken, cancellationTokenSource.Token).ConfigureAwait(false))
+                    using (ClientWebSocket webSocket = await DeviceStreamingCommon.GetStreamingClientAsync(streamRequest.Uri, streamRequest.AuthorizationToken, cancellationTokenSource.Token).ConfigureAwait(false))
                     {
                         using (TcpClient tcpClient = new TcpClient())
                         {
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
                             }
                         }
 
-                        await webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, String.Empty, cancellationTokenSource.Token).ConfigureAwait(false);
+                        await webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, cancellationTokenSource.Token).ConfigureAwait(false);
                     }
                 }
                 else

--- a/iot-hub/Quickstarts/device-streams-proxy/device/Program.cs
+++ b/iot-hub/Quickstarts/device-streams-proxy/device/Program.cs
@@ -33,9 +33,9 @@ namespace Microsoft.Azure.Devices.Client.Samples
 
         // Select one of the following transports used by DeviceClient to connect to IoT Hub.
         private static readonly TransportType s_transportType = TransportType.Amqp;
-        //private static TransportType s_transportType = TransportType.Mqtt;
-        //private static TransportType s_transportType = TransportType.Amqp_WebSocket_Only;
-        //private static TransportType s_transportType = TransportType.Mqtt_WebSocket_Only;
+        //private static readonly TransportType s_transportType = TransportType.Mqtt;
+        //private static readonly TransportType s_transportType = TransportType.Amqp_WebSocket_Only;
+        //private static readonly TransportType s_transportType = TransportType.Mqtt_WebSocket_Only;
 
         public static int Main(string[] args)
         {

--- a/iot-hub/Quickstarts/device-streams-proxy/device/Program.cs
+++ b/iot-hub/Quickstarts/device-streams-proxy/device/Program.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
 {
     public static class Program
     {
-        // String containing Hostname, Device Id & Device Key in one of the following formats:
+        // String containing Host Name, Device Id & Device Key in one of the following formats:
         //  "HostName=<iothub_host_name>;DeviceId=<device_id>;SharedAccessKey=<device_key>"
         //  "HostName=<iothub_host_name>;CredentialType=SharedAccessSignature;DeviceId=<device_id>;SharedAccessSignature=SharedAccessSignature sr=<iot_host>/devices/<device_id>&sig=<token>&se=<expiry_time>";
 
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
         private static string s_port = Environment.GetEnvironmentVariable("REMOTE_PORT");
 
         // Select one of the following transports used by DeviceClient to connect to IoT Hub.
-        private static TransportType s_transportType = TransportType.Amqp;
+        private static readonly TransportType s_transportType = TransportType.Amqp;
         //private static TransportType s_transportType = TransportType.Mqtt;
         //private static TransportType s_transportType = TransportType.Amqp_WebSocket_Only;
         //private static TransportType s_transportType = TransportType.Mqtt_WebSocket_Only;

--- a/iot-hub/Quickstarts/device-streams-proxy/service/DeviceStreamSample.cs
+++ b/iot-hub/Quickstarts/device-streams-proxy/service/DeviceStreamSample.cs
@@ -14,11 +14,11 @@ namespace Microsoft.Azure.Devices.Samples
 {
     public class DeviceStreamSample
     {
-        private ServiceClient _serviceClient;
-        private String _deviceId;
-        private int _localPort;
+        private readonly ServiceClient _serviceClient;
+        private readonly string _deviceId;
+        private readonly int _localPort;
 
-        public DeviceStreamSample(ServiceClient deviceClient, String deviceId, int localPort)
+        public DeviceStreamSample(ServiceClient deviceClient, string deviceId, int localPort)
         {
             _serviceClient = deviceClient;
             _deviceId = deviceId;
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.Devices.Samples
                     try
                     {
                         using (var cancellationTokenSource = new CancellationTokenSource())
-                        using (var remoteStream = await DeviceStreamingCommon.GetStreamingClientAsync(result.Url, result.AuthorizationToken, cancellationTokenSource.Token).ConfigureAwait(false))
+                        using (var remoteStream = await DeviceStreamingCommon.GetStreamingClientAsync(result.Uri, result.AuthorizationToken, cancellationTokenSource.Token).ConfigureAwait(false))
                         {
                             Console.WriteLine("Starting streaming");
 
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.Devices.Samples
                                 HandleOutgoingDataAsync(localStream, remoteStream, cancellationTokenSource.Token)).ConfigureAwait(false);
                         }
 
-                            Console.WriteLine("Done streaming");
+                        Console.WriteLine("Done streaming");
                     }
                     catch (Exception ex)
                     {

--- a/iot-hub/Quickstarts/device-streams-proxy/service/Program.cs
+++ b/iot-hub/Quickstarts/device-streams-proxy/service/Program.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Devices.Samples
 
         // Select one of the following transports used by ServiceClient to connect to IoT Hub.
         private static readonly TransportType s_transportType = TransportType.Amqp;
-        //private static TransportType s_transportType = TransportType.Amqp_WebSocket_Only;
+        //private static readonly TransportType s_transportType = TransportType.Amqp_WebSocket_Only;
 
         public static int Main(string[] args)
         {

--- a/iot-hub/Quickstarts/device-streams-proxy/service/Program.cs
+++ b/iot-hub/Quickstarts/device-streams-proxy/service/Program.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Devices.Samples
         private static string s_port = Environment.GetEnvironmentVariable("LOCAL_PORT");
 
         // Select one of the following transports used by ServiceClient to connect to IoT Hub.
-        private static TransportType s_transportType = TransportType.Amqp;
+        private static readonly TransportType s_transportType = TransportType.Amqp;
         //private static TransportType s_transportType = TransportType.Amqp_WebSocket_Only;
 
         public static int Main(string[] args)

--- a/iot-hub/Quickstarts/device-streams-proxy/service/ServiceLocalProxyStreamingSample.csproj
+++ b/iot-hub/Quickstarts/device-streams-proxy/service/ServiceLocalProxyStreamingSample.csproj
@@ -10,9 +10,9 @@
   </ItemGroup>
 
   <ItemGroup>
-  	<PackageReference Include="Microsoft.Azure.Devices" Version="1.27.0-preview-*" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.28.0-preview-001" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.2" />
   </ItemGroup>


### PR DESCRIPTION
We cannot use floating version in our DeviceStreaming samples because they need to have the preview versions selected and the floating version specification does not work for us because our preview versions are not considered the latest version in our history

![image](https://user-images.githubusercontent.com/18057016/101674140-f89d2980-3a0c-11eb-9b27-5dc72ce350a6.png)

As you can see here, 1.28.0 is considered a newer package than 1.28.0-preview-001 so we can't use floating version to fetch this package as per:
https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#floating-version-resolutions