### PR TITLE
Update Program.cs

### DIFF
--- a/iot-hub/Quickstarts/ReadD2cMessages/Program.cs
+++ b/iot-hub/Quickstarts/ReadD2cMessages/Program.cs
@@ -100,13 +100,13 @@ namespace ReadD2cMessages
                     Console.WriteLine("\tApplication properties (set by device):");
                     foreach (KeyValuePair<string, object> prop in partitionEvent.Data.Properties)
                     {
-                        Console.WriteLine($"\t\t{prop.Key}: {prop.Value}");
+                        PrintProperties(prop);
                     }
 
                     Console.WriteLine("\tSystem properties (set by IoT Hub):");
                     foreach (KeyValuePair<string, object> prop in partitionEvent.Data.SystemProperties)
                     {
-                        Console.WriteLine($"\t\t{prop.Key}: {prop.Value}");
+                        PrintProperties(prop);
                     }
                 }
             }
@@ -115,6 +115,18 @@ namespace ReadD2cMessages
                 // This is expected when the token is signaled; it should not be considered an
                 // error in this scenario.
             }
+        }
+
+        private static void PrintProperties(KeyValuePair<string, object> prop) 
+        {
+            string propValue = prop.Value.ToString();
+            if (prop.Value is DateTime) 
+            {
+                // Include the millisecond portion when printing the date
+                propValue = ((DateTime)prop.Value).ToString("MM/dd/yyyy hh:mm:ss.fff tt");
+            }
+
+            Console.WriteLine($"\t\t{prop.Key}: {propValue}");
         }
     }
 }

--- a/iot-hub/Quickstarts/ReadD2cMessages/Program.cs
+++ b/iot-hub/Quickstarts/ReadD2cMessages/Program.cs
@@ -119,12 +119,9 @@ namespace ReadD2cMessages
 
         private static void PrintProperties(KeyValuePair<string, object> prop) 
         {
-            string propValue = prop.Value.ToString();
-            if (prop.Value is DateTime) 
-            {
-                // Include the millisecond portion when printing the date
-                propValue = ((DateTime)prop.Value).ToString("MM/dd/yyyy hh:mm:ss.fff tt");
-            }
+            string propValue = prop.Value is DateTime
+                ? ((DateTime)prop.Value).ToString("O") // using a built-in date format here that includes milliseconds
+                : prop.Value.ToString();
 
             Console.WriteLine($"\t\t{prop.Key}: {propValue}");
         }


### PR DESCRIPTION
Include the millisecond portion when printing the date

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* The code was previously printing the DateTime of the enqueuedTime message system property without the millisecond portion, giving users the idea that iot hub was dropping the milliseconds somewhere before routing to the endpoint, which is not the case. The reason is because by default printing DateTime as is will not include the milliseconds as explained [here](https://docs.microsoft.com/en-us/dotnet/standard/base-types/how-to-display-milliseconds-in-date-and-time-values). This ensures that if printing a DateTime object, it will do it in the format required to include the millisecond portion.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe:
``` Addressing the confusion that iot hub is not dropping the milliseconds from the enqueuedTime system property.

## How to Test
*  Run the ReadD2cMessages project, iothub-enqueuedtime property should now also include the millisecond portion.

## Other Information
<!-- Add any other helpful information that may be needed here. -->