### PR TITLE
Fix Wrong TransportFallbackType

### DIFF
--- a/provisioning/Samples/device/SymmetricKeySample/ProvisioningDeviceClientSample.cs
+++ b/provisioning/Samples/device/SymmetricKeySample/ProvisioningDeviceClientSample.cs
@@ -107,11 +107,11 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Samples
             return _parameters.TransportType switch
             {
                 TransportType.Mqtt => new ProvisioningTransportHandlerMqtt(),
-                TransportType.Mqtt_Tcp_Only => new ProvisioningTransportHandlerMqtt(TransportFallbackType.WebSocketOnly),
-                TransportType.Mqtt_WebSocket_Only => new ProvisioningTransportHandlerMqtt(TransportFallbackType.TcpOnly),
+                TransportType.Mqtt_Tcp_Only => new ProvisioningTransportHandlerMqtt(TransportFallbackType.TcpOnly),
+                TransportType.Mqtt_WebSocket_Only => new ProvisioningTransportHandlerMqtt(TransportFallbackType.WebSocketOnly),
                 TransportType.Amqp => new ProvisioningTransportHandlerAmqp(),
-                TransportType.Amqp_Tcp_Only => new ProvisioningTransportHandlerAmqp(TransportFallbackType.WebSocketOnly),
-                TransportType.Amqp_WebSocket_Only => new ProvisioningTransportHandlerAmqp(TransportFallbackType.TcpOnly),
+                TransportType.Amqp_Tcp_Only => new ProvisioningTransportHandlerAmqp(TransportFallbackType.TcpOnly),
+                TransportType.Amqp_WebSocket_Only => new ProvisioningTransportHandlerAmqp(TransportFallbackType.WebSocketOnly),
                 TransportType.Http1 => new ProvisioningTransportHandlerHttp(),
                 _ => throw new NotSupportedException($"Unsupported transport type {_parameters.TransportType}"),
             };

--- a/provisioning/Samples/device/TpmSample/ProvisioningDeviceClientSample.cs
+++ b/provisioning/Samples/device/TpmSample/ProvisioningDeviceClientSample.cs
@@ -94,8 +94,8 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Samples
             return _parameters.TransportType switch
             {
                 TransportType.Amqp => new ProvisioningTransportHandlerAmqp(),
-                TransportType.Amqp_Tcp_Only => new ProvisioningTransportHandlerAmqp(TransportFallbackType.WebSocketOnly),
-                TransportType.Amqp_WebSocket_Only => new ProvisioningTransportHandlerAmqp(TransportFallbackType.TcpOnly),
+                TransportType.Amqp_Tcp_Only => new ProvisioningTransportHandlerAmqp(TransportFallbackType.TcpOnly),
+                TransportType.Amqp_WebSocket_Only => new ProvisioningTransportHandlerAmqp(TransportFallbackType.WebSocketOnly),
                 TransportType.Http1 => new ProvisioningTransportHandlerHttp(),
                 TransportType.Mqtt => throw new NotSupportedException("MQTT is not supported for TPM"),
                 TransportType.Mqtt_Tcp_Only => throw new NotSupportedException("MQTT is not supported for TPM"),

--- a/provisioning/Samples/device/X509Sample/ProvisioningDeviceClientSample.cs
+++ b/provisioning/Samples/device/X509Sample/ProvisioningDeviceClientSample.cs
@@ -74,11 +74,11 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Samples
             return _parameters.TransportType switch
             {
                 TransportType.Mqtt => new ProvisioningTransportHandlerMqtt(),
-                TransportType.Mqtt_Tcp_Only => new ProvisioningTransportHandlerMqtt(TransportFallbackType.WebSocketOnly),
-                TransportType.Mqtt_WebSocket_Only => new ProvisioningTransportHandlerMqtt(TransportFallbackType.TcpOnly),
+                TransportType.Mqtt_Tcp_Only => new ProvisioningTransportHandlerMqtt(TransportFallbackType.TcpOnly),
+                TransportType.Mqtt_WebSocket_Only => new ProvisioningTransportHandlerMqtt(TransportFallbackType.WebSocketOnly),
                 TransportType.Amqp => new ProvisioningTransportHandlerAmqp(),
-                TransportType.Amqp_Tcp_Only => new ProvisioningTransportHandlerAmqp(TransportFallbackType.WebSocketOnly),
-                TransportType.Amqp_WebSocket_Only => new ProvisioningTransportHandlerAmqp(TransportFallbackType.TcpOnly),
+                TransportType.Amqp_Tcp_Only => new ProvisioningTransportHandlerAmqp(TransportFallbackType.TcpOnly),
+                TransportType.Amqp_WebSocket_Only => new ProvisioningTransportHandlerAmqp(TransportFallbackType.WebSocketOnly),
                 TransportType.Http1 => new ProvisioningTransportHandlerHttp(),
                 _ => throw new NotSupportedException($"Unsupported transport type {_parameters.TransportType}"),
             };


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
The switch case for determining the TransportType had the wrong enumerations in the constructor. Basically you wanted  TcpOnly TransportType but got WebSocketOnly. 

Fixed the issue by providing the right TransportType in each case. 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
