### PR TITLE
Close all device client instances before disposing them

### DIFF
--- a/iot-hub/Quickstarts/SimulatedDevice/Program.cs
+++ b/iot-hub/Quickstarts/SimulatedDevice/Program.cs
@@ -51,6 +51,8 @@ namespace SimulatedDevice
             // Run the telemetry loop
             await SendDeviceToCloudMessagesAsync(cts.Token);
 
+            await s_deviceClient.CloseAsync(cts.Token);
+
             s_deviceClient.Dispose();
             Console.WriteLine("Device simulator finished.");
         }

--- a/iot-hub/Quickstarts/SimulatedDeviceWithCommand/Program.cs
+++ b/iot-hub/Quickstarts/SimulatedDeviceWithCommand/Program.cs
@@ -57,6 +57,7 @@ namespace SimulatedDevice
             // Run the telemetry loop
             await SendDeviceToCloudMessagesAsync(cts.Token);
 
+            await s_deviceClient.CloseAsync(cts.Token);
             s_deviceClient.Dispose();
             Console.WriteLine("Device simulator finished.");
         }

--- a/iot-hub/Samples/device/DeviceReconnectionSample/DeviceReconnectionSample.cs
+++ b/iot-hub/Samples/device/DeviceReconnectionSample/DeviceReconnectionSample.cs
@@ -90,6 +90,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
                         // If the device client instance has been previously initialized, then dispose it.
                         if (s_deviceClient != null)
                         {
+                            s_deviceClient.CloseAsync().GetAwaiter().GetResult(); // cannot await a task in a lock statement
                             s_deviceClient.Dispose();
                             s_deviceClient = null;
                         }

--- a/iot-hub/Samples/device/DeviceReconnectionSample/DeviceReconnectionSample.cs
+++ b/iot-hub/Samples/device/DeviceReconnectionSample/DeviceReconnectionSample.cs
@@ -74,6 +74,8 @@ namespace Microsoft.Azure.Devices.Client.Samples
             {
                 _logger.LogError($"Unrecoverable exception caught, user action is required, so exiting...: \n{ex}");
             }
+
+            _initSemaphore.Dispose();
         }
 
         private async Task InitializeAndOpenClientAsync()

--- a/iot-hub/Samples/device/DeviceStreamingSample/Program.cs
+++ b/iot-hub/Samples/device/DeviceStreamingSample/Program.cs
@@ -35,6 +35,8 @@ namespace Microsoft.Azure.Devices.Client.Samples
             var sample = new DeviceStreamSample(deviceClient);
             await sample.RunSampleAsync();
 
+            await deviceClient.CloseAsync();
+
             Console.WriteLine("Done.");
             return 0;
         }

--- a/iot-hub/Samples/device/FileUploadSample/Program.cs
+++ b/iot-hub/Samples/device/FileUploadSample/Program.cs
@@ -40,6 +40,8 @@ namespace Microsoft.Azure.Devices.Client.Samples
             var sample = new FileUploadSample(deviceClient);
             await sample.RunSampleAsync();
 
+            await deviceClient.CloseAsync();
+
             Console.WriteLine("Done.");
             return 0;
         }

--- a/iot-hub/Samples/device/MessageReceiveSample/Program.cs
+++ b/iot-hub/Samples/device/MessageReceiveSample/Program.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
                 parameters.TransportType);
             var sample = new MessageReceiveSample(deviceClient);
             await sample.RunSampleAsync();
+            await deviceClient.CloseAsync();
 
             Console.WriteLine("Done.");
             return 0;

--- a/iot-hub/Samples/device/MethodSample/Program.cs
+++ b/iot-hub/Samples/device/MethodSample/Program.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
                 parameters.TransportType);
             var sample = new MethodSample(deviceClient);
             await sample.RunSampleAsync(runningTime);
+            await deviceClient.CloseAsync();
 
             Console.WriteLine("Done.");
             return 0;

--- a/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController/Program.cs
+++ b/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController/Program.cs
@@ -60,6 +60,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
             using DeviceClient deviceClient = await SetupDeviceClientAsync(parameters, cts.Token);
             var sample = new TemperatureControllerSample(deviceClient, s_logger);
             await sample.PerformOperationsAsync(cts.Token);
+            await deviceClient.CloseAsync(cts.Token);
         }
 
         private static ILogger InitializeConsoleDebugLogger()

--- a/iot-hub/Samples/device/TwinSample/Program.cs
+++ b/iot-hub/Samples/device/TwinSample/Program.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
                 parameters.TransportType);
             var sample = new TwinSample(deviceClient);
             await sample.RunSampleAsync(runningTime);
+            await deviceClient.CloseAsync();
 
             Console.WriteLine("Done.");
             return 0;

--- a/iot-hub/Samples/device/X509DeviceCertWithChainSample/Program.cs
+++ b/iot-hub/Samples/device/X509DeviceCertWithChainSample/Program.cs
@@ -47,6 +47,7 @@ namespace X509DeviceCertWithChainSample
 
             var sample = new X509DeviceCertWithChainSample(deviceClient);
             await sample.RunSampleAsync();
+            await deviceClient.CloseAsync();
 
             return 0;
         }

--- a/iot-hub/Tutorials/Routing/SimulatedDevice/Program.cs
+++ b/iot-hub/Tutorials/Routing/SimulatedDevice/Program.cs
@@ -63,6 +63,7 @@ namespace SimulatedDevice
                 var messages = SendDeviceToCloudMessagesAsync(cts.Token);
                 Console.WriteLine("Press the Enter key to stop.");
                 Console.ReadLine();
+                await s_deviceClient.CloseAsync(cts.Token);
                 cts.Cancel();
                 await messages;
 


### PR DESCRIPTION
The best practice for safely disposing of a device client instance is to close it first, and then dispose it. These samples need to be updated to reflect that