### PR TITLE
feat(samples): Sample to use msi with import and export jobs.

### DIFF
--- a/iot-hub/Samples/service/ImportExportDevicesWithManagedIdentitySample/ImportExportDevicesWithManagedIdentitySample.csproj
+++ b/iot-hub/Samples/service/ImportExportDevicesWithManagedIdentitySample/ImportExportDevicesWithManagedIdentitySample.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <LangVersion>8</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.8.0" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.27.2" />
+    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.1.3" />
+  </ItemGroup>
+
+</Project>

--- a/iot-hub/Samples/service/ImportExportDevicesWithManagedIdentitySample/ImportExportDevicesWithManagedidentitySample.cs
+++ b/iot-hub/Samples/service/ImportExportDevicesWithManagedIdentitySample/ImportExportDevicesWithManagedidentitySample.cs
@@ -1,0 +1,150 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Azure.Devices;
+using System;
+using System.Threading.Tasks;
+
+namespace ImportExportDevicesWithManagedIdentitySample
+{
+    /// <summary>
+    /// A sample to illustrate how to perform import and export jobs using managed identity 
+    /// to access the storage account. This sample will copy all the devices in the source hub
+    /// to the destination hub.
+    /// For this sample to succeed, the managed identity should be configured to access the 
+    /// storage account used for import and export.
+    /// For more information on configuration, see TODO <see href=""/>.
+    /// For more information on managed identities, see <see href="https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview"/>
+    /// </summary>
+    public class ImportExportDevicesWithManagedidentitySample
+    {
+        public async Task RunSampleAsync(string sourceHubConnectionString,
+            string destinationHubConnectionString,
+            string blobContainerUri,
+            ManagedIdentityType identityType,
+            string userDefinedManagedIdentityResourceId = null)
+        {
+            if (identityType == ManagedIdentityType.UserDefined
+                && string.IsNullOrWhiteSpace(userDefinedManagedIdentityResourceId))
+            {
+                    throw new ArgumentNullException(nameof(userDefinedManagedIdentityResourceId),
+                        "userDefinedManagedIdentityResourceId is required if identityType is UserDefined.");
+            }
+
+            Console.WriteLine($"Exporting devices from source hub to {blobContainerUri}/devices.txt.");
+            await ExportDevicesAsync(sourceHubConnectionString,
+                blobContainerUri,
+                identityType,
+                userDefinedManagedIdentityResourceId);
+            Console.WriteLine("Exporting devices completed.");
+
+            Console.WriteLine($"Importing devices from {blobContainerUri}/devices.txt to destination hub.");
+            await ImportDevicesAsync(destinationHubConnectionString,
+                blobContainerUri,
+                identityType,
+                userDefinedManagedIdentityResourceId);  
+            Console.WriteLine("Importing devices completed.");
+        }
+
+        public async Task ExportDevicesAsync(string hubConnectionString,
+            string blobContainerUri,
+            ManagedIdentityType identityType,
+            string userDefinedManagedIdentityResourceId = null)
+        {
+            using RegistryManager srcRegistryManager = RegistryManager.CreateFromConnectionString(hubConnectionString);            
+
+            JobProperties jobProperties = new JobProperties
+            {
+                OutputBlobContainerUri = blobContainerUri,
+                StorageAuthenticationType = StorageAuthenticationType.IdentityBased
+            };
+
+            // Configure the ManagedIdentity if identityType is UserDefined.
+            // This value will be ignored if identityType is SystemDefined.
+            // The default is SystemDefined if StorageAuthenticationType is set to IdentityBased.
+            if (identityType == ManagedIdentityType.UserDefined)
+            {
+                jobProperties.Identity = new ManagedIdentity
+                {
+                    userAssignedIdentity = userDefinedManagedIdentityResourceId
+                };
+            }
+
+            JobProperties jobResult = await srcRegistryManager
+                .ExportDevicesAsync(jobProperties);
+
+            // Poll every 5 seconds to see if the job has finished executing.
+            while (true)
+            {
+                jobResult = await srcRegistryManager.GetJobAsync(jobResult.JobId);
+                if (jobResult.Status == JobStatus.Completed)
+                {
+                    break;
+                }
+                else if (jobResult.Status == JobStatus.Failed)
+                {
+                    throw new Exception("Export job failed.");
+                }
+                else if (jobResult.Status == JobStatus.Cancelled)
+                {
+                    throw new Exception("Export job was canceled.");
+                }
+                else
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(5));
+                }
+            }
+        }
+
+        public async Task ImportDevicesAsync(string hubConnectionString,
+            string blobContainerUri,
+            ManagedIdentityType identityType,
+            string userDefinedManagedIdentityResourceId = null)
+        {
+            using RegistryManager destRegistryManager = RegistryManager.CreateFromConnectionString(hubConnectionString);
+
+            JobProperties jobProperties = new JobProperties
+            {
+                InputBlobContainerUri = blobContainerUri,
+                OutputBlobContainerUri = blobContainerUri,
+                StorageAuthenticationType = StorageAuthenticationType.IdentityBased
+            };
+
+            // Configure the ManagedIdentity if identityType is UserDefined.
+            // This value will be ignored if identityType is SystemDefined.
+            // The default is SystemDefined if StorageAuthenticationType is set to IdentityBased.
+            if (identityType == ManagedIdentityType.UserDefined)
+            {
+                jobProperties.Identity = new ManagedIdentity
+                {
+                    userAssignedIdentity = userDefinedManagedIdentityResourceId
+                };
+            }
+
+            JobProperties jobResult = await destRegistryManager
+                .ImportDevicesAsync(jobProperties);
+
+            // Poll every 5 seconds to see if the job has finished executing.
+            while (true)
+            {
+                jobResult = await destRegistryManager.GetJobAsync(jobResult.JobId);
+                if (jobResult.Status == JobStatus.Completed)
+                {
+                    break;
+                }
+                else if (jobResult.Status == JobStatus.Failed)
+                {
+                    throw new Exception("Import job failed.");
+                }
+                else if (jobResult.Status == JobStatus.Cancelled)
+                {
+                    throw new Exception("Import job was canceled.");
+                }
+                else
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(5));
+                }
+            }
+        }
+    }
+}

--- a/iot-hub/Samples/service/ImportExportDevicesWithManagedIdentitySample/ManagedIdentityType.cs
+++ b/iot-hub/Samples/service/ImportExportDevicesWithManagedIdentitySample/ManagedIdentityType.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ImportExportDevicesWithManagedIdentitySample
+{
+    /// <summary>
+    /// The type for managed identity to use in import and export jobs.
+    /// </summary>
+    public enum ManagedIdentityType
+    {
+        SystemDefined,
+        UserDefined
+    }
+}

--- a/iot-hub/Samples/service/ImportExportDevicesWithManagedIdentitySample/Parameters.cs
+++ b/iot-hub/Samples/service/ImportExportDevicesWithManagedIdentitySample/Parameters.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using CommandLine;
+
+namespace ImportExportDevicesWithManagedIdentitySample
+{
+    /// <summary>
+    /// Parameters for the application.
+    /// </summary>
+    internal class Parameters
+    {
+        [Option(
+            "sourceHubConnectionString",
+            Required = true,
+            HelpText = "The connection string of the source IoT Hub.")]
+        public string SourceHubConnectionString { get; set; }
+
+        [Option(
+           "destinationHubConnectionString",
+           Required = true,
+           HelpText = "The connection string of the destination IoT Hub.")]
+        public string DestinationHubConnectionString { get; set; }
+
+        [Option(
+            "blobContainerUri",
+            Required = true,
+            HelpText = "The Uri of storage container for import and export jobs.")]
+        public string BlobContainerUri { get; set; }
+
+        [Option(
+           "identityType",
+           Required = true,
+           HelpText = "The type of managed identity to use. Possible values are SystemDefined and UserDefined.")]
+        public ManagedIdentityType IdentityType { get; set; }
+
+        [Option(
+            "userDefinedManagedIdentityResourceId",
+            Required = false,
+            HelpText = "The resource Id of the user defined managed identity. This is only required when the identityType is set to UserDefined.")]
+        public string UserDefinedManagedIdentityResourceId { get; set; }
+    }
+}

--- a/iot-hub/Samples/service/ImportExportDevicesWithManagedIdentitySample/Program.cs
+++ b/iot-hub/Samples/service/ImportExportDevicesWithManagedIdentitySample/Program.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using CommandLine;
+using System;
+using System.Threading.Tasks;
+
+namespace ImportExportDevicesWithManagedIdentitySample
+{
+    /// <summary>
+    /// A sample to illustrate how to perform import and export jobs using managed identity 
+    /// to access the storage account. This sample will copy all the devices in the source hub
+    /// to the destination hub.
+    /// For this sample to succeed, the managed identity should be configured to access the 
+    /// storage account used for import and export.
+    /// For more information on configuration, see TODO <see href=""/>.
+    /// For more information on managed identities, see <see href="https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview"/>
+    /// </summary>
+    public class Program
+    {        
+        public static async Task Main(string[] args)
+        {
+            // Parse application parameters
+            Parameters parameters = null;
+            ParserResult<Parameters> result = Parser.Default.ParseArguments<Parameters>(args)
+                .WithParsed(parsedParams =>
+                {
+                    parameters = parsedParams;
+                })
+                .WithNotParsed(errors =>
+                {
+                    Environment.Exit(1);
+                });
+
+            var sample = new ImportExportDevicesWithManagedidentitySample();
+
+            await sample.RunSampleAsync(parameters.SourceHubConnectionString,
+                parameters.DestinationHubConnectionString,
+                parameters.BlobContainerUri,
+                parameters.IdentityType,
+                parameters.UserDefinedManagedIdentityResourceId);
+        }
+
+    }
+}

--- a/iot-hub/Samples/service/IoTHubServiceSamples.sln
+++ b/iot-hub/Samples/service/IoTHubServiceSamples.sln
@@ -31,6 +31,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TemperatureController", "Pn
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ColorConsoleLogger", "..\..\..\helpers\ColorConsoleLogger\ColorConsoleLogger.csproj", "{DBABF65A-F2E7-4736-9B99-D760E664B9C6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImportExportDevicesWithManagedIdentitySample", "ImportExportDevicesWithManagedIdentitySample\ImportExportDevicesWithManagedIdentitySample.csproj", "{958EBE9D-6AB8-4F06-B854-25D43D6825D1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -185,6 +187,18 @@ Global
 		{DBABF65A-F2E7-4736-9B99-D760E664B9C6}.Release|x64.Build.0 = Release|Any CPU
 		{DBABF65A-F2E7-4736-9B99-D760E664B9C6}.Release|x86.ActiveCfg = Release|Any CPU
 		{DBABF65A-F2E7-4736-9B99-D760E664B9C6}.Release|x86.Build.0 = Release|Any CPU
+		{958EBE9D-6AB8-4F06-B854-25D43D6825D1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{958EBE9D-6AB8-4F06-B854-25D43D6825D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{958EBE9D-6AB8-4F06-B854-25D43D6825D1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{958EBE9D-6AB8-4F06-B854-25D43D6825D1}.Debug|x64.Build.0 = Debug|Any CPU
+		{958EBE9D-6AB8-4F06-B854-25D43D6825D1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{958EBE9D-6AB8-4F06-B854-25D43D6825D1}.Debug|x86.Build.0 = Debug|Any CPU
+		{958EBE9D-6AB8-4F06-B854-25D43D6825D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{958EBE9D-6AB8-4F06-B854-25D43D6825D1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{958EBE9D-6AB8-4F06-B854-25D43D6825D1}.Release|x64.ActiveCfg = Release|Any CPU
+		{958EBE9D-6AB8-4F06-B854-25D43D6825D1}.Release|x64.Build.0 = Release|Any CPU
+		{958EBE9D-6AB8-4F06-B854-25D43D6825D1}.Release|x86.ActiveCfg = Release|Any CPU
+		{958EBE9D-6AB8-4F06-B854-25D43D6825D1}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
Adding some context to this new feature on hub - The JobProperties now have a new property called 'identity'. As long as we pass the correct identity in the import/export jobs, IoThub will use it internally to interact with the storage account to do things like upload devices.txt. From the SDK's perspective, we just need to be able to send this new property in JobProperties. The sample shows how to do it. I will setup a brown bag later to show how to setup managed identities and the e2e flow. But that should not be required to review this sample.