### PR TITLE
Refactor DPS symmetric key samples to show best practices

### DIFF
--- a/provisioning/Samples/device/ComputeDerivedSymmetricKeySample/ComputeDerivedKeySample.cs
+++ b/provisioning/Samples/device/ComputeDerivedSymmetricKeySample/ComputeDerivedKeySample.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Microsoft.Azure.Devices.Provisioning.Client.Samples
+{
+    /// <summary>
+    /// This sample demonstrates how to derive the symmetric key for a particular device enrollment within an enrollment
+    /// group. Best security practices dictate that the enrollment group level symmetric key should never be saved to a
+    /// particular device, so this code is deliberately separate from the SymmetricKeySample in this same directory. 
+    /// Users are advised to run this code to generate the derived symmetric key once, and to save
+    /// the derived key to the device. Users are not advised to derive the device symmetric key from the enrollment group
+    /// level key within each device as that is insecure.
+    /// </summary>
+    internal class ComputeDerivedKeySample
+    {
+        private readonly Parameters _parameters;
+
+        public ComputeDerivedKeySample(Parameters parameters)
+        {
+            _parameters = parameters;
+        }
+
+        public void RunSample()
+        {
+            string derivedKey = ComputeDerivedSymmetricKey(_parameters.PrimaryKey, _parameters.Id);
+
+            Console.WriteLine("Your derived key is:");
+            Console.WriteLine(derivedKey);
+        }
+
+
+        /// <summary>
+        /// Compute a symmetric key for the provisioned device from the enrollment group symmetric key used in attestation.
+        /// </summary>
+        /// <param name="enrollmentKey">Enrollment group symmetric key.</param>
+        /// <param name="deviceId">The device Id of the key to create.</param>
+        /// <returns>The key for the specified device Id registration in the enrollment group.</returns>
+        /// <seealso>
+        /// https://docs.microsoft.com/en-us/azure/iot-edge/how-to-auto-provision-symmetric-keys?view=iotedge-2018-06#derive-a-device-key
+        /// </seealso>
+        private static string ComputeDerivedSymmetricKey(string enrollmentKey, string deviceId)
+        {
+            if (string.IsNullOrWhiteSpace(enrollmentKey))
+            {
+                return enrollmentKey;
+            }
+
+            using var hmac = new HMACSHA256(Convert.FromBase64String(enrollmentKey));
+            return Convert.ToBase64String(hmac.ComputeHash(Encoding.UTF8.GetBytes(deviceId)));
+        }
+    }
+}

--- a/provisioning/Samples/device/ComputeDerivedSymmetricKeySample/ComputeDerivedKeySample.cs
+++ b/provisioning/Samples/device/ComputeDerivedSymmetricKeySample/ComputeDerivedKeySample.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Samples
     /// particular device, so this code is deliberately separate from the SymmetricKeySample in this same directory. 
     /// Users are advised to run this code to generate the derived symmetric key once, and to save
     /// the derived key to the device. Users are not advised to derive the device symmetric key from the enrollment group
-    /// level key within each device as that is insecure.
+    /// level key within each device as that is unsecure.
     /// </summary>
     internal class ComputeDerivedKeySample
     {

--- a/provisioning/Samples/device/ComputeDerivedSymmetricKeySample/ComputeDerivedSymmetricKeySample.csproj
+++ b/provisioning/Samples/device/ComputeDerivedSymmetricKeySample/ComputeDerivedSymmetricKeySample.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+	  <OutputType>Exe</OutputType>
+	  <TargetFramework>netcoreapp2.1</TargetFramework>
+	  <LangVersion>8.0</LangVersion>
+	  <RootNamespace>Microsoft.Azure.Devices.Provisioning.Client.Samples</RootNamespace>
+  </PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="CommandLineParser" Version="2.8.0" />
+	</ItemGroup>
+</Project>

--- a/provisioning/Samples/device/ComputeDerivedSymmetricKeySample/Parameters.cs
+++ b/provisioning/Samples/device/ComputeDerivedSymmetricKeySample/Parameters.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using CommandLine;
+
+namespace Microsoft.Azure.Devices.Provisioning.Client.Samples
+{
+    /// <summary>
+    /// Parameters for the application
+    /// </summary>
+    internal class Parameters
+    {
+        [Option(
+            'i',
+            "Id",
+            Required = true,
+            HelpText = "The desired device Id of the device that will use this derived key.")]
+        public string Id { get; set; }
+
+        [Option(
+            'p',
+            "PrimaryKey",
+            Required = true,
+            HelpText = "The primary key of the group enrollment.")]
+        public string PrimaryKey { get; set; }
+    }
+}

--- a/provisioning/Samples/device/ComputeDerivedSymmetricKeySample/Program.cs
+++ b/provisioning/Samples/device/ComputeDerivedSymmetricKeySample/Program.cs
@@ -1,0 +1,32 @@
+﻿using CommandLine;
+using Microsoft.Azure.Devices.Provisioning.Client.Samples;
+using System;
+
+namespace ComputeDerivedSymmetricKeySample
+{
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            // Parse application parameters
+            Parameters parameters = null;
+            ParserResult<Parameters> result = Parser.Default.ParseArguments<Parameters>(args)
+                .WithParsed(parsedParams =>
+                {
+                    parameters = parsedParams;
+                })
+                .WithNotParsed(errors =>
+                {
+                    Environment.Exit(1);
+                });
+
+            var sample = new ComputeDerivedKeySample(parameters);
+            sample.RunSample();
+
+            Console.WriteLine("Enter any key to exit.");
+            Console.ReadKey();
+
+            return 0;
+        }
+    }
+}

--- a/provisioning/Samples/device/ProvisioningDeviceSamples.sln
+++ b/provisioning/Samples/device/ProvisioningDeviceSamples.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27004.2009
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31129.286
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TpmSample", "TpmSample\TpmSample.csproj", "{995317C2-9D36-477A-8781-94C1F0C3A87F}"
 EndProject
@@ -9,7 +9,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "X509Sample", "X509Sample\X5
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SecurityProviderTpmSimulator", "..\..\..\security\Samples\SecurityProviderTpmSimulator\SecurityProviderTpmSimulator.csproj", "{3B888FEC-552E-4FCE-9126-147695BE4F7F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SymmetricKeySample", "SymmetricKeySample\SymmetricKeySample.csproj", "{7148297F-B361-43FD-96A8-77305AA2B263}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SymmetricKeySample", "SymmetricKeySample\SymmetricKeySample.csproj", "{7148297F-B361-43FD-96A8-77305AA2B263}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ComputeDerivedSymmetricKeySample", "ComputeDerivedSymmetricKeySample\ComputeDerivedSymmetricKeySample.csproj", "{3557CC19-72B6-462E-9BF4-E3675D54E67F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -33,6 +35,10 @@ Global
 		{7148297F-B361-43FD-96A8-77305AA2B263}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7148297F-B361-43FD-96A8-77305AA2B263}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7148297F-B361-43FD-96A8-77305AA2B263}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3557CC19-72B6-462E-9BF4-E3675D54E67F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3557CC19-72B6-462E-9BF4-E3675D54E67F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3557CC19-72B6-462E-9BF4-E3675D54E67F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3557CC19-72B6-462E-9BF4-E3675D54E67F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/provisioning/Samples/device/SymmetricKeySample/Parameters.cs
+++ b/provisioning/Samples/device/SymmetricKeySample/Parameters.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Samples
             'p',
             "PrimaryKey",
             Required = true,
-            HelpText = "The primary key of the individual or group enrollment.")]
+            HelpText = "The primary key of the individual enrollment or the derived primary key of the group enrollment. See the ComputeDerivedSymmetricKeySample for how to generate the derived key.")]
         public string PrimaryKey { get; set; }
 
         [Option(

--- a/provisioning/Samples/device/SymmetricKeySample/ProvisioningDeviceClientSample.cs
+++ b/provisioning/Samples/device/SymmetricKeySample/ProvisioningDeviceClientSample.cs
@@ -26,14 +26,6 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Samples
 
         public async Task RunSampleAsync()
         {
-            // When registering with a symmetric key using a group enrollment, the provided key will not
-            // work for a specific device, rather it must be computed based on two values: the group enrollment
-            // key and the desired device Id.
-            if (_parameters.EnrollmentType == EnrollmentType.Group)
-            {
-                _parameters.PrimaryKey = ComputeDerivedSymmetricKey(_parameters.PrimaryKey, _parameters.Id);
-            }
-
             Console.WriteLine($"Initializing the device provisioning client...");
 
             // For individual enrollments, the first parameter must be the registration Id, where in the enrollment
@@ -80,26 +72,6 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Samples
             await iotClient.SendEventAsync(message);
 
             Console.WriteLine("Finished.");
-        }
-
-        /// <summary>
-        /// Compute a symmetric key for the provisioned device from the enrollment group symmetric key used in attestation.
-        /// </summary>
-        /// <param name="enrollmentKey">Enrollment group symmetric key.</param>
-        /// <param name="deviceId">The device Id of the key to create.</param>
-        /// <returns>The key for the specified device Id registration in the enrollment group.</returns>
-        /// <seealso>
-        /// https://docs.microsoft.com/en-us/azure/iot-edge/how-to-auto-provision-symmetric-keys?view=iotedge-2018-06#derive-a-device-key
-        /// </seealso>
-        private static string ComputeDerivedSymmetricKey(string enrollmentKey, string deviceId)
-        {
-            if (string.IsNullOrWhiteSpace(enrollmentKey))
-            {
-                return enrollmentKey;
-            }
-
-            using var hmac = new HMACSHA256(Convert.FromBase64String(enrollmentKey));
-            return Convert.ToBase64String(hmac.ComputeHash(Encoding.UTF8.GetBytes(deviceId)));
         }
 
         private ProvisioningTransportHandler GetTransportHandler()


### PR DESCRIPTION
We need to separate the derivation of the device-specific symmetric key to a different sample as per the service team's recommendation. Users shouldn't save the enrollment group level key to each device, and that's what our sample showed previously