### PR TITLE
 Do not delete e2e test resources on PR builds

### DIFF
--- a/iot-hub/Samples/service/CleanupDevicesSample/csharp_devices_list.csv
+++ b/iot-hub/Samples/service/CleanupDevicesSample/csharp_devices_list.csv
@@ -7,3 +7,4 @@ tpm-registration-id-
 ModuleNotFoundTestSasl_
 RegistryManager_
 EdgeDeploymentSample_
+RegistryManagerSample_

--- a/iot-hub/Samples/service/CleanupDevicesSample/csharp_samples_devices_list.csv
+++ b/iot-hub/Samples/service/CleanupDevicesSample/csharp_samples_devices_list.csv
@@ -1,0 +1,2 @@
+RegistryManagerSample_
+EdgeDeploymentSample_

--- a/iot-hub/Samples/service/RegistryManagerSample/Parameters.cs
+++ b/iot-hub/Samples/service/RegistryManagerSample/Parameters.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Devices.Samples
             'd',
             "DevicePrefix",
             Required = false,
-            Default = "RegistryManagerSample-",
+            Default = "RegistryManagerSample_",
             HelpText = "The prefix to use when creating devices.")]
         public string DevicePrefix { get; set; }
     }

--- a/vsts/vsts.yaml
+++ b/vsts/vsts.yaml
@@ -53,6 +53,10 @@ jobs:
           IOTHUB_PFX_X509_THUMBPRINT: $(IOTHUB-PFX-X509-THUMBPRINT)
           DPS_IDSCOPE: $(DPS-IDSCOPE)
           PROVISIONING_CONNECTION_STRING: $(PROVISIONING-CONNECTION-STRING)
+          # PATH-TO-DEVICE-PREFIX-FOR-DELETION-FILE is a variable configured on the pipeline. The possible values are: csharp_devices_list.csv, csharp_samples_devices_list.csv.
+          # The value of this variable determines whether to delete devices created by the sample or e2e tests.
+          # csharp_devices_list.csv contains the prefixes of devices created by e2e tests.
+          # csharp_samples_devices_list.csv contains the prefixes of devices created by samples.
           PATH_TO_DEVICE_PREFIX_FOR_DELETION_FILE: $(PATH-TO-DEVICE-PREFIX-FOR-DELETION-FILE)
           STORAGE_ACCOUNT_CONNECTION_STRING: $(STORAGE-ACCOUNT-CONNECTION-STRING)
           FAR_AWAY_IOTHUB_CONNECTION_STRING: $(FAR-AWAY-IOTHUB-CONNECTION-STRING)
@@ -104,6 +108,10 @@ jobs:
           IOTHUB_PFX_X509_THUMBPRINT: $(IOTHUB-PFX-X509-THUMBPRINT)
           DPS_IDSCOPE: $(DPS-IDSCOPE)
           PROVISIONING_CONNECTION_STRING: $(PROVISIONING-CONNECTION-STRING)
+          # PATH-TO-DEVICE-PREFIX-FOR-DELETION-FILE is a variable configured on the pipeline. The possible values are: csharp_devices_list.csv, csharp_samples_devices_list.csv.
+          # The value of this variable determines whether to delete devices created by the sample or e2e tests.
+          # csharp_devices_list.csv contains the prefixes of devices created by e2e tests.
+          # csharp_samples_devices_list.csv contains the prefixes of devices created by samples.
           PATH_TO_DEVICE_PREFIX_FOR_DELETION_FILE: $(PATH-TO-DEVICE-PREFIX-FOR-DELETION-FILE)
           STORAGE_ACCOUNT_CONNECTION_STRING: $(STORAGE-ACCOUNT-CONNECTION-STRING)
           FAR_AWAY_IOTHUB_CONNECTION_STRING: $(FAR-AWAY-IOTHUB-CONNECTION-STRING)


### PR DESCRIPTION
This PR mainly moves the configuration of which devices to delete to the pipeline variable rather than a constant value. Once this is checked in, the scheduled run will run as normal, running all tests and cleaning up both e2e and sample created devices.

Apart from that pipeline, I"ll add a new pipeline that will only delete the sample created devices along with running the samples. This pipeline will be enabled on PR builds.

After this is complete, I will make merge these changes to preview branch and create a PR pipeline for the preview branch as well.