### PR TITLE
Get twin on device connect for PnpDeviceSamples

### DIFF
--- a/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController/TemperatureController.csproj
+++ b/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController/TemperatureController.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootDir>$(MSBuildProjectDirectory)\..\..\..\..\..</RootDir>
   </PropertyGroup>
 
@@ -19,6 +19,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\PnpConvention\PnpHelpers.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\..\helpers\ColorConsoleLogger\ColorConsoleLogger.csproj" />
   </ItemGroup>
 
 </Project>

--- a/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController/TemperatureControllerSample.cs
+++ b/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController/TemperatureControllerSample.cs
@@ -139,7 +139,8 @@ namespace Microsoft.Azure.Devices.Client.Samples
             // side without comparing the property values.
             if (serverWritablePropertiesVersion > s_localWritablePropertiesVersion)
             {
-                _logger.LogDebug($"The writable property version cached on local is changing from {s_localWritablePropertiesVersion} to {serverWritablePropertiesVersion}.");
+                _logger.LogInformation($"The writable property version cached on local is changing " +
+                    $"from {s_localWritablePropertiesVersion} to {serverWritablePropertiesVersion}.");
 
                 foreach (KeyValuePair<string, object> propertyUpdate in twinCollection)
                 {
@@ -162,7 +163,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
                     }
                 }
 
-                _logger.LogDebug($"The writable property version on local is currently {s_localWritablePropertiesVersion}.");
+                _logger.LogInformation($"The writable property version on local is currently {s_localWritablePropertiesVersion}.");
             }
         }
 

--- a/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController/TemperatureControllerSample.cs
+++ b/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController/TemperatureControllerSample.cs
@@ -52,6 +52,12 @@ namespace Microsoft.Azure.Devices.Client.Samples
         // Dictionary to hold the max temperature since last reboot, for each "Thermostat" component.
         private readonly Dictionary<string, double> _maxTemp = new Dictionary<string, double>();
 
+        // A safe initial value for caching the writable properties version is 1, so the client
+        // will process all previous property change requests and initialize the device application
+        // after which this version will be updated to that, so we have a high water mark of which version number
+        // has been processed.
+        private static long s_localWritablePropertiesVersion = 1;
+
         public TemperatureControllerSample(DeviceClient deviceClient, ILogger logger)
         {
             _deviceClient = deviceClient ?? throw new ArgumentNullException($"{nameof(deviceClient)} cannot be null.");
@@ -61,6 +67,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
         public async Task PerformOperationsAsync(CancellationToken cancellationToken)
         {
             // This sample follows the following workflow:
+            // -> Set handler to receive and respond to connection status changes.
             // -> Set handler to receive "reboot" command - root interface.
             // -> Set handler to receive "getMaxMinReport" command - on "Thermostat" components.
             // -> Set handler to receive "targetTemperature" property updates from service - on "Thermostat" components.
@@ -69,6 +76,18 @@ namespace Microsoft.Azure.Devices.Client.Samples
             // -> Periodically send "temperature" over telemetry - on "Thermostat" components.
             // -> Send "maxTempSinceLastReboot" over property update, when a new max temperature is set - on "Thermostat" components.
 
+            _deviceClient.SetConnectionStatusChangesHandler(async (status, reason) =>
+            {
+                _logger.LogDebug($"Connection status change registered - status={status}, reason={reason}.");
+
+                // Call GetWritablePropertiesAndHandleChangesAsync() to get writable properties from the server once the connection status changes into Connected.
+                // This can get back "lost" property updates in a device reconnection from status Disconnected_Retrying or Disconnected.
+                if (status == ConnectionStatus.Connected)
+                {
+                    await GetWritablePropertiesAndHandleChangesAsync();
+                }
+            });
+            
             _logger.LogDebug("Set handler for 'reboot' command.");
             await _deviceClient.SetMethodHandlerAsync("reboot", HandleRebootCommandAsync, _deviceClient, cancellationToken);
 
@@ -104,6 +123,46 @@ namespace Microsoft.Azure.Devices.Client.Samples
 
                 temperatureReset = _temperature[Thermostat1] == 0 && _temperature[Thermostat2] == 0;
                 await Task.Delay(5 * 1000);
+            }
+        }
+
+        private async Task GetWritablePropertiesAndHandleChangesAsync()
+        {
+            Twin twin = await _deviceClient.GetTwinAsync();
+            _logger.LogInformation($"Device retrieving twin values on CONNECT: {twin.ToJson()}");
+
+            TwinCollection twinCollection = twin.Properties.Desired;
+            long serverWritablePropertiesVersion = twinCollection.Version;
+
+            // Check if the writable property version is outdated on the local side.
+            // For the purpose of this sample, we'll only check the writable property versions between local and server
+            // side without comparing the property values.
+            if (serverWritablePropertiesVersion > s_localWritablePropertiesVersion)
+            {
+                _logger.LogDebug($"The writable property version cached on local is changing from {s_localWritablePropertiesVersion} to {serverWritablePropertiesVersion}.");
+
+                foreach (KeyValuePair<string, object> propertyUpdate in twinCollection)
+                {
+                    string componentName = propertyUpdate.Key;
+                    switch (componentName)
+                    {
+                        case Thermostat1:
+                        case Thermostat2:
+                            if (!_temperature.TryGetValue(componentName, out double value))
+                            { 
+                                _temperature[componentName] = 0d;
+                            }
+                            await TargetTemperatureUpdateCallbackAsync(twinCollection, componentName);
+                            break;
+
+                        default:
+                            _logger.LogWarning($"Property: Received an unrecognized property update from service:" +
+                                $"\n[ {propertyUpdate.Key}: {propertyUpdate.Value} ].");
+                            break;
+                    }
+                }
+
+                _logger.LogDebug($"The writable property version on local is currently {s_localWritablePropertiesVersion}.");
             }
         }
 
@@ -229,6 +288,8 @@ namespace Microsoft.Azure.Devices.Client.Samples
             }
 
             _logger.LogDebug($"Property: Received - component=\"{componentName}\", {{ \"{propertyName}\": {targetTemperature}°C }}.");
+
+            s_localWritablePropertiesVersion = desiredProperties.Version;
 
             TwinCollection pendingReportedProperty = PnpConvention.CreateComponentWritablePropertyResponse(
                 componentName,

--- a/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController/TemperatureControllerSample.cs
+++ b/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController/TemperatureControllerSample.cs
@@ -149,9 +149,10 @@ namespace Microsoft.Azure.Devices.Client.Samples
                     {
                         case Thermostat1:
                         case Thermostat2:
+                            // This will be called when a device client gets initialized and the _temperature dictionary is still empty.
                             if (!_temperature.TryGetValue(componentName, out double value))
                             { 
-                                _temperature[componentName] = 0d;
+                                _temperature[componentName] = 21d; // The default temperature value is 21°C.
                             }
                             await TargetTemperatureUpdateCallbackAsync(twinCollection, componentName);
                             break;

--- a/iot-hub/Samples/device/PnpDeviceSamples/Thermostat/Program.cs
+++ b/iot-hub/Samples/device/PnpDeviceSamples/Thermostat/Program.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using CommandLine;
+using Microsoft.Azure.Devices.Logging;
 using Microsoft.Azure.Devices.Provisioning.Client;
 using Microsoft.Azure.Devices.Provisioning.Client.Transport;
 using Microsoft.Azure.Devices.Shared;
@@ -33,7 +34,19 @@ namespace Microsoft.Azure.Devices.Client.Samples
                     Environment.Exit(1);
                 });
 
-            s_logger = InitializeConsoleDebugLogger();
+            // Set up logging
+            ILoggerFactory loggerFactory = new LoggerFactory();
+            loggerFactory.AddColorConsoleLogger(
+                new ColorConsoleLoggerConfiguration
+                {
+                    MinLogLevel = LogLevel.Debug,
+                });
+            s_logger = loggerFactory.CreateLogger<Program>();
+
+            const string SdkEventProviderPrefix = "Microsoft-Azure-";
+            // Instantiating this seems to do all we need for outputting SDK events to our console log
+            _ = new ConsoleEventListener(SdkEventProviderPrefix, s_logger);
+
             if (!parameters.Validate(s_logger))
             {
                 throw new ArgumentException("Required parameters are not set. Please recheck required variables by using \"--help\"");
@@ -133,10 +146,6 @@ namespace Microsoft.Azure.Devices.Client.Samples
             };
 
             DeviceClient deviceClient = DeviceClient.CreateFromConnectionString(deviceConnectionString, TransportType.Mqtt, options);
-            deviceClient.SetConnectionStatusChangesHandler((status, reason) =>
-            {
-                s_logger.LogDebug($"Connection status change registered - status={status}, reason={reason}.");
-            });
 
             return deviceClient;
         }
@@ -151,10 +160,6 @@ namespace Microsoft.Azure.Devices.Client.Samples
             };
 
             DeviceClient deviceClient = DeviceClient.Create(hostname, authenticationMethod, TransportType.Mqtt, options);
-            deviceClient.SetConnectionStatusChangesHandler((status, reason) =>
-            {
-                s_logger.LogDebug($"Connection status change registered - status={status}, reason={reason}.");
-            });
 
             return deviceClient;
         }

--- a/iot-hub/Samples/device/PnpDeviceSamples/Thermostat/Thermostat.csproj
+++ b/iot-hub/Samples/device/PnpDeviceSamples/Thermostat/Thermostat.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <RootDir>$(MSBuildProjectDirectory)\..\..\..\..\..</RootDir>
     <RootNamespace>Microsoft.Azure.Devices.Client.Samples</RootNamespace>
@@ -18,4 +18,9 @@
     <!-- Working around a bug between DotNetty and .NET 5.0+ by specifying the exact version of DotNetty.Common that has the fix -->
     <PackageReference Include="DotNetty.Common" Version="0.7.1" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\..\helpers\ColorConsoleLogger\ColorConsoleLogger.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/iot-hub/Samples/device/PnpDeviceSamples/Thermostat/ThermostatSample.cs
+++ b/iot-hub/Samples/device/PnpDeviceSamples/Thermostat/ThermostatSample.cs
@@ -36,6 +36,12 @@ namespace Microsoft.Azure.Devices.Client.Samples
         private readonly DeviceClient _deviceClient;
         private readonly ILogger _logger;
 
+        // A safe initial value for caching the writable properties version is 1, so the client
+        // will process all previous property change requests and initialize the device application
+        // after which this version will be updated to that, so we have a high water mark of which version number
+        // has been processed.
+        private static long s_localWritablePropertiesVersion = 1;
+
         public ThermostatSample(DeviceClient deviceClient, ILogger logger)
         {
             _deviceClient = deviceClient ?? throw new ArgumentNullException($"{nameof(deviceClient)} cannot be null.");
@@ -45,10 +51,23 @@ namespace Microsoft.Azure.Devices.Client.Samples
         public async Task PerformOperationsAsync(CancellationToken cancellationToken)
         {
             // This sample follows the following workflow:
+            // -> Set handler to receive and respond to connection status changes.
             // -> Set handler to receive "targetTemperature" updates, and send the received update over reported property.
             // -> Set handler to receive "getMaxMinReport" command, and send the generated report as command response.
             // -> Periodically send "temperature" over telemetry.
             // -> Send "maxTempSinceLastReboot" over property update, when a new max temperature is set.
+
+            _deviceClient.SetConnectionStatusChangesHandler(async (status, reason) =>
+            {
+                _logger.LogDebug($"Connection status change registered - status={status}, reason={reason}.");
+
+                // Call GetWritablePropertiesAndHandleChangesAsync() to get writable properties from the server once the connection status changes into Connected.
+                // This can get back "lost" property updates in a device reconnection from status Disconnected_Retrying or Disconnected.
+                if (status == ConnectionStatus.Connected)
+                {
+                    await GetWritablePropertiesAndHandleChangesAsync();
+                }
+            });
 
             _logger.LogDebug($"Set handler to receive \"targetTemperature\" updates.");
             await _deviceClient.SetDesiredPropertyUpdateCallbackAsync(TargetTemperatureUpdateCallbackAsync, _deviceClient, cancellationToken);
@@ -71,6 +90,38 @@ namespace Microsoft.Azure.Devices.Client.Samples
             }
         }
 
+        private async Task GetWritablePropertiesAndHandleChangesAsync()
+        {
+            Twin twin = await _deviceClient.GetTwinAsync();
+            _logger.LogInformation($"Device retrieving twin values on CONNECT: {twin.ToJson()}");
+
+            TwinCollection twinCollection = twin.Properties.Desired;
+            long serverWritablePropertiesVersion = twinCollection.Version;
+
+            // Check if the writable property version is outdated on the local side.
+            // For the purpose of this sample, we'll only check the writable property versions between local and server
+            // side without comparing the property values.
+            if (serverWritablePropertiesVersion > s_localWritablePropertiesVersion)
+            {
+                _logger.LogDebug($"The writable property version cached on local is changing from {s_localWritablePropertiesVersion} to {serverWritablePropertiesVersion}.");
+
+                foreach (KeyValuePair<string, object> propertyUpdate in twinCollection)
+                {
+                    string componentName = propertyUpdate.Key;
+                    if (componentName == "targetTemperature")
+                    {
+                        await TargetTemperatureUpdateCallbackAsync(twinCollection, componentName);
+                    }
+                    else
+                    {
+                        _logger.LogWarning($"Property: Received an unrecognized property update from service:\n[ {propertyUpdate.Key}: {propertyUpdate.Value} ].");
+                    }
+                }
+
+                _logger.LogDebug($"The writable property version on local is currently {s_localWritablePropertiesVersion}.");
+            }
+        }
+
         // The desired property update callback, which receives the target temperature as a desired property update,
         // and updates the current temperature value over telemetry and reported property update.
         private async Task TargetTemperatureUpdateCallbackAsync(TwinCollection desiredProperties, object userContext)
@@ -81,6 +132,8 @@ namespace Microsoft.Azure.Devices.Client.Samples
             if (targetTempUpdateReceived)
             {
                 _logger.LogDebug($"Property: Received - {{ \"{propertyName}\": {targetTemperature}°C }}.");
+
+                s_localWritablePropertiesVersion = desiredProperties.Version;
 
                 string jsonPropertyPending = $"{{ \"{propertyName}\": {{ \"value\": {_temperature}, \"ac\": {(int)StatusCode.InProgress}, " +
                     $"\"av\": {desiredProperties.Version} }} }}";

--- a/iot-hub/Samples/device/PnpDeviceSamples/Thermostat/ThermostatSample.cs
+++ b/iot-hub/Samples/device/PnpDeviceSamples/Thermostat/ThermostatSample.cs
@@ -103,7 +103,8 @@ namespace Microsoft.Azure.Devices.Client.Samples
             // side without comparing the property values.
             if (serverWritablePropertiesVersion > s_localWritablePropertiesVersion)
             {
-                _logger.LogDebug($"The writable property version cached on local is changing from {s_localWritablePropertiesVersion} to {serverWritablePropertiesVersion}.");
+                _logger.LogInformation($"The writable property version cached on local is changing " +
+                    $"from {s_localWritablePropertiesVersion} to {serverWritablePropertiesVersion}.");
 
                 foreach (KeyValuePair<string, object> propertyUpdate in twinCollection)
                 {
@@ -114,11 +115,12 @@ namespace Microsoft.Azure.Devices.Client.Samples
                     }
                     else
                     {
-                        _logger.LogWarning($"Property: Received an unrecognized property update from service:\n[ {propertyUpdate.Key}: {propertyUpdate.Value} ].");
+                        _logger.LogWarning($"Property: Received an unrecognized property update from service:" +
+                            $"\n[ {propertyUpdate.Key}: {propertyUpdate.Value} ].");
                     }
                 }
 
-                _logger.LogDebug($"The writable property version on local is currently {s_localWritablePropertiesVersion}.");
+                _logger.LogInformation($"The writable property version on local is currently {s_localWritablePropertiesVersion}.");
             }
         }
 


### PR DESCRIPTION
Get writable properties from server on CONNECT and check if local version is outdated, similar to this [PR](https://github.com/Azure-Samples/azure-iot-samples-csharp/pull/261).