### PR TITLE
Update ConventionBasedOperations Sample

### DIFF
--- a/iot-hub/Samples/device/ConventionBasedOperations/TemperatureController/ClientResponseCodes.cs
+++ b/iot-hub/Samples/device/ConventionBasedOperations/TemperatureController/ClientResponseCodes.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Azure.Devices.Shared;
+
+namespace Microsoft.Azure.Devices.Client.Samples
+{
+    // The specific response codes in this sample.
+    public class ClientResponseCodes : CommonClientResponseCodes
+    {
+        /// <summary>
+        /// This code does not comply with HTTP semantics. Instead, it indicates that the device client
+        /// reports the default value with ACK when its properties are empty.
+        /// </summary>
+        public const int Default = 203;
+    }
+}

--- a/iot-hub/Samples/device/ConventionBasedOperations/TemperatureController/ClientResponseCodes.cs
+++ b/iot-hub/Samples/device/ConventionBasedOperations/TemperatureController/ClientResponseCodes.cs
@@ -12,6 +12,6 @@ namespace Microsoft.Azure.Devices.Client.Samples
         /// This code does not comply with HTTP semantics. Instead, it indicates that the device client
         /// reports the default value with ACK when its properties are empty.
         /// </summary>
-        public const int Default = 203;
+        public const int DeviceInitialProperty = 203;
     }
 }

--- a/iot-hub/Samples/device/ConventionBasedOperations/TemperatureController/Program.cs
+++ b/iot-hub/Samples/device/ConventionBasedOperations/TemperatureController/Program.cs
@@ -138,8 +138,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
         }
 
         // Initialize the device client instance using connection string based authentication, over Mqtt protocol (TCP, with fallback over Websocket) and
-        // setting the ModelId into ClientOptions.This method also sets a connection status change callback, that will get triggered any time the device's
-        // connection status changes.
+        // setting the ModelId into ClientOptions.
         private static DeviceClient InitializeDeviceClient(string deviceConnectionString)
         {
             // Specify a custom System.Text.Json based PayloadConvention to be used.
@@ -154,7 +153,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
         }
 
         // Initialize the device client instance using symmetric key based authentication, over Mqtt protocol (TCP, with fallback over Websocket)
-        // and setting the ModelId into ClientOptions. This method also sets a connection status change callback, that will get triggered any time the device's connection status changes.
+        // and setting the ModelId into ClientOptions. 
         private static DeviceClient InitializeDeviceClient(string hostname, IAuthenticationMethod authenticationMethod)
         {
             var options = new ClientOptions

--- a/iot-hub/Samples/device/ConventionBasedOperations/TemperatureController/TemperatureControllerSample.cs
+++ b/iot-hub/Samples/device/ConventionBasedOperations/TemperatureController/TemperatureControllerSample.cs
@@ -514,18 +514,18 @@ namespace Microsoft.Azure.Devices.Client.Samples
             // Check if the device properties for the current component are empty.
             if (!writableProperty.Contains(componentName) && !reportedProperty.Contains(componentName))
             {
-                await ReportDefault(componentName, TargetTemperatureProperty, cancellationToken);
+                await ReportInitialProperty(componentName, TargetTemperatureProperty, cancellationToken);
             }
         }
 
-        private async Task ReportDefault(string componentName, string propertyName, CancellationToken cancellationToken)
+        private async Task ReportInitialProperty(string componentName, string propertyName, CancellationToken cancellationToken)
         {
             var reportedProperties = new ClientPropertyCollection();
 
             // Report the default value with ACK(ac=203, av=0) as part of the PnP convention.
             // "DefaultPropertyValue" is set from the device when the desired property is not set via the hub.
             var propertyValue = _deviceClient.PayloadConvention.PayloadSerializer.CreateWritablePropertyResponse(
-                DefaultPropertyValue, ClientResponseCodes.Default, 0, DefaultACKDescription);
+                DefaultPropertyValue, ClientResponseCodes.DeviceInitialProperty, 0, DefaultACKDescription);
 
             reportedProperties.AddComponentProperty(componentName, propertyName, propertyValue);
 

--- a/iot-hub/Samples/device/ConventionBasedOperations/TemperatureController/TemperatureControllerSample.cs
+++ b/iot-hub/Samples/device/ConventionBasedOperations/TemperatureController/TemperatureControllerSample.cs
@@ -14,9 +14,11 @@ namespace Microsoft.Azure.Devices.Client.Samples
 {
     public class TemperatureControllerSample
     {
-        // The default reported "value" and "ad" for each "Thermostat" component on the client initial startup.
+        // The default reported "value", "ad" and "av" for each "Thermostat" component on the client initial startup.
+        // See https://docs.microsoft.com/en-us/azure/iot-develop/concepts-convention#writable-properties for more details in acknowledgment responses.
         private const double DefaultPropertyValue = 0d;
         private const string DefaultACKDescription = "Initialized with default value";
+        private const long DefaultACKVersion = 0L;
 
         private const string TargetTemperatureProperty = "targetTemperature";
         
@@ -525,7 +527,10 @@ namespace Microsoft.Azure.Devices.Client.Samples
             // Report the default value with ACK(ac=203, av=0) as part of the PnP convention.
             // "DefaultPropertyValue" is set from the device when the desired property is not set via the hub.
             var propertyValue = _deviceClient.PayloadConvention.PayloadSerializer.CreateWritablePropertyResponse(
-                DefaultPropertyValue, ClientResponseCodes.DeviceInitialProperty, 0, DefaultACKDescription);
+                DefaultPropertyValue, 
+                ClientResponseCodes.DeviceInitialProperty, 
+                DefaultACKVersion, 
+                DefaultACKDescription);
 
             reportedProperties.AddComponentProperty(componentName, propertyName, propertyValue);
 

--- a/iot-hub/Samples/device/ConventionBasedOperations/TemperatureController/TemperatureControllerSample.cs
+++ b/iot-hub/Samples/device/ConventionBasedOperations/TemperatureController/TemperatureControllerSample.cs
@@ -18,9 +18,8 @@ namespace Microsoft.Azure.Devices.Client.Samples
         private const string Thermostat1 = "thermostat1";
         private const string Thermostat2 = "thermostat2";
 
-        // The default reported "value" and "ad" for each "Thermostat" component.
+        // The default reported "value" for each "Thermostat" component.
         private const double defaultPropertyValue = 0d;
-        private const string defaultAckDescription = "Property set from the device without desired";
 
         private static readonly Random s_random = new Random();
         private static readonly TimeSpan s_sleepDuration = TimeSpan.FromSeconds(5);
@@ -523,14 +522,13 @@ namespace Microsoft.Azure.Devices.Client.Samples
 
             // If the writable properties for the current component are empty, report the default value with ACK(ac=203, av=0).
             var propertyValue = _deviceClient.PayloadConvention.PayloadSerializer.CreateWritablePropertyResponse(
-                defaultPropertyValue, 203, 
-                0, defaultAckDescription);
+                defaultPropertyValue, 203, 0);
 
             reportedProperties.AddComponentProperty(componentName, propertyName, propertyValue);
 
             ClientPropertiesUpdateResponse updateResponse = await _deviceClient.UpdateClientPropertiesAsync(reportedProperties, cancellationToken);
 
-            _logger.LogDebug($"Property: Update - component=\"{componentName}\", {reportedProperties.GetSerializedString()}" +
+            _logger.LogDebug($"Report the default values for \"{componentName}\".\nProperty: Update - component=\"{componentName}\", {reportedProperties.GetSerializedString()}" +
                 $" in °C is complete with a version of {updateResponse.Version}.");
         }
     }

--- a/iot-hub/Samples/device/ConventionBasedOperations/TemperatureController/TemperatureControllerSample.cs
+++ b/iot-hub/Samples/device/ConventionBasedOperations/TemperatureController/TemperatureControllerSample.cs
@@ -121,14 +121,16 @@ namespace Microsoft.Azure.Devices.Client.Samples
 
             if (!writableProperties.Contains(Thermostat1))
             {
-                // Report the default property "targetTemperature" with ACK for the component "thermostat1" when the writable properties are empty.
+                // Update the reported property "targetTemperature" with the default values and ACK
+                // for the component "thermostat1" when its writable properties are empty.
                 // This is a component-level property update call.
                 await UpdateReportedPropertiesWhenWritablePropertiesEmptyAsync(Thermostat1, cancellationToken);
             }
             
             if (!writableProperties.Contains(Thermostat2))
             {
-                // Report the default property "targetTemperature" with ACK for the component "thermostat2" when the writable properties are empty.
+                // Update the reported property "targetTemperature" with the default values and ACK
+                // for the component "thermostat2" when its writable properties are empty.
                 // This is a component-level property update call.
                 await UpdateReportedPropertiesWhenWritablePropertiesEmptyAsync(Thermostat2, cancellationToken);
             }

--- a/iot-hub/Samples/device/ConventionBasedOperations/TemperatureController/TemperatureControllerSample.cs
+++ b/iot-hub/Samples/device/ConventionBasedOperations/TemperatureController/TemperatureControllerSample.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
         private const string Thermostat2 = "thermostat2";
 
         // The default reported "value" for each "Thermostat" component.
-        private const double defaultPropertyValue = 0d;
+        private const double DefaultPropertyValue = 0d;
 
         private static readonly Random s_random = new Random();
         private static readonly TimeSpan s_sleepDuration = TimeSpan.FromSeconds(5);
@@ -124,7 +124,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
                 // Update the reported property "targetTemperature" with the default values and ACK
                 // for the component "thermostat1" when its writable properties are empty.
                 // This is a component-level property update call.
-                await UpdateReportedPropertiesWhenWritablePropertiesEmptyAsync(Thermostat1, cancellationToken);
+                await UpdateForEmptyWritableProperty(Thermostat1, cancellationToken);
             }
             
             if (!writableProperties.Contains(Thermostat2))
@@ -132,7 +132,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
                 // Update the reported property "targetTemperature" with the default values and ACK
                 // for the component "thermostat2" when its writable properties are empty.
                 // This is a component-level property update call.
-                await UpdateReportedPropertiesWhenWritablePropertiesEmptyAsync(Thermostat2, cancellationToken);
+                await UpdateForEmptyWritableProperty(Thermostat2, cancellationToken);
             }
 
             // Check if the writable property version is outdated on the local side.
@@ -516,15 +516,16 @@ namespace Microsoft.Azure.Devices.Client.Samples
             return Math.Round(s_random.NextDouble() * (max - min) + min, 1);
         }
 
-        private async Task UpdateReportedPropertiesWhenWritablePropertiesEmptyAsync(string componentName, CancellationToken cancellationToken)
+        private async Task UpdateForEmptyWritableProperty(string componentName, CancellationToken cancellationToken)
         {
             const string propertyName = "targetTemperature";
             
             var reportedProperties = new ClientPropertyCollection();
 
-            // If the writable properties for the current component are empty, report the default value with ACK(ac=203, av=0).
+            // If the writable properties are empty, report the default value with ACK(ac=203, av=0) as part of the PnP convention.
+            // "DefaultPropertyValue" is set from the device when the desired property is not set via the hub.
             var propertyValue = _deviceClient.PayloadConvention.PayloadSerializer.CreateWritablePropertyResponse(
-                defaultPropertyValue, 203, 0);
+                DefaultPropertyValue, 203, 0);
 
             reportedProperties.AddComponentProperty(componentName, propertyName, propertyValue);
 

--- a/iot-hub/Samples/device/ConventionBasedOperations/TemperatureController/TemperatureControllerSample.cs
+++ b/iot-hub/Samples/device/ConventionBasedOperations/TemperatureController/TemperatureControllerSample.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.Devices.Shared;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 
@@ -15,21 +14,11 @@ namespace Microsoft.Azure.Devices.Client.Samples
 {
     public class TemperatureControllerSample
     {
-        // The specific response codes in this sample.
-        public class ClientResponseCodes : CommonClientResponseCodes
-        {
-            /// <summary>
-            /// This code does not comply with HTTP semantics. Instead, it indicates that the device client
-            /// reports the default value with ACK when its properties are empty.
-            /// </summary>
-            public const int Default = 203;
-        }
-
         // The default reported "value" and "ad" for each "Thermostat" component on the client initial startup.
         private const double DefaultPropertyValue = 0d;
         private const string DefaultACKDescription = "Initialized with default value";
 
-        private const string SamplePropertyName = "targetTemperature";
+        private const string TargetTemperatureProperty = "targetTemperature";
         
         private const string Thermostat1 = "thermostat1";
         private const string Thermostat2 = "thermostat2";
@@ -156,9 +145,9 @@ namespace Microsoft.Azure.Devices.Client.Samples
                             // WritableClientProperty, which provides convenience methods for acknowledging the requests. Since property
                             // update requests that were potentially lost during reconnection can be retrieved only as a collection of property
                             // values, and not as a collection of WritableClientProperty, we will need to create the property response ack by ourselves.
-                            if (writableProperties.TryGetValue(componentName, SamplePropertyName, out double targetTemperatureValue))
+                            if (writableProperties.TryGetValue(componentName, TargetTemperatureProperty, out double targetTemperatureValue))
                             { 
-                                _logger.LogDebug($"Property: Received - component=\"{componentName}\", [ \"{SamplePropertyName}\": {targetTemperatureValue}°C ].");
+                                _logger.LogDebug($"Property: Received - component=\"{componentName}\", [ \"{TargetTemperatureProperty}\": {targetTemperatureValue}°C ].");
 
                                 _temperature[componentName] = targetTemperatureValue;
 
@@ -170,7 +159,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
                                     serverWritablePropertiesVersion);
 
                                 var reportedProperty = new ClientPropertyCollection();
-                                reportedProperty.AddComponentProperty(componentName, SamplePropertyName, propertyValue);
+                                reportedProperty.AddComponentProperty(componentName, TargetTemperatureProperty, propertyValue);
 
                                 ClientPropertiesUpdateResponse updateResponse = await _deviceClient.UpdateClientPropertiesAsync(reportedProperty);
 
@@ -209,7 +198,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
                     case Thermostat1:
                     case Thermostat2:
                         string componentName = writableProperty.Key;
-                        if (writableProperties.TryGetValue(componentName, SamplePropertyName, out WritableClientProperty targetTemperatureRequested))
+                        if (writableProperties.TryGetValue(componentName, TargetTemperatureProperty, out WritableClientProperty targetTemperatureRequested))
                         {
                             await HandleTargetTemperatureUpdateRequestAsync(componentName, targetTemperatureRequested);
                             break;
@@ -236,12 +225,12 @@ namespace Microsoft.Azure.Devices.Client.Samples
         private async Task HandleTargetTemperatureUpdateRequestAsync(string componentName, WritableClientProperty targetTemperatureUpdateRequest)
         {
             double targetTemperatureValue = SystemTextJsonPayloadSerializer.Instance.ConvertFromObject<double>(targetTemperatureUpdateRequest.Value);
-            _logger.LogDebug($"Property: Received - component=\"{componentName}\", [ \"{SamplePropertyName}\": {targetTemperatureValue}°C ].");
+            _logger.LogDebug($"Property: Received - component=\"{componentName}\", [ \"{TargetTemperatureProperty}\": {targetTemperatureValue}°C ].");
 
             _temperature[componentName] = targetTemperatureValue;
 
             var reportedProperty = new ClientPropertyCollection();
-            reportedProperty.AddComponentProperty(componentName, SamplePropertyName, targetTemperatureUpdateRequest.AcknowledgeWith(ClientResponseCodes.OK));
+            reportedProperty.AddComponentProperty(componentName, TargetTemperatureProperty, targetTemperatureUpdateRequest.AcknowledgeWith(ClientResponseCodes.OK));
 
             ClientPropertiesUpdateResponse updateResponse = await _deviceClient.UpdateClientPropertiesAsync(reportedProperty);
 
@@ -525,7 +514,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
             // Check if the device properties for the current component are empty.
             if (!writableProperty.Contains(componentName) && !reportedProperty.Contains(componentName))
             {
-                await ReportDefault(componentName, SamplePropertyName, cancellationToken);
+                await ReportDefault(componentName, TargetTemperatureProperty, cancellationToken);
             }
         }
 

--- a/iot-hub/Samples/device/ConventionBasedOperations/Thermostat/ClientResponseCodes.cs
+++ b/iot-hub/Samples/device/ConventionBasedOperations/Thermostat/ClientResponseCodes.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Azure.Devices.Shared;
+
+namespace Microsoft.Azure.Devices.Client.Samples
+{
+    // The specific response codes in this sample.
+    public class ClientResponseCodes : CommonClientResponseCodes
+    {
+        /// <summary>
+        /// This code does not comply with HTTP semantics. Instead, it indicates that the device client
+        /// reports the default value with ACK when its properties are empty.
+        /// </summary>
+        public const int Default = 203;
+    }
+}

--- a/iot-hub/Samples/device/ConventionBasedOperations/Thermostat/ClientResponseCodes.cs
+++ b/iot-hub/Samples/device/ConventionBasedOperations/Thermostat/ClientResponseCodes.cs
@@ -12,6 +12,6 @@ namespace Microsoft.Azure.Devices.Client.Samples
         /// This code does not comply with HTTP semantics. Instead, it indicates that the device client
         /// reports the default value with ACK when its properties are empty.
         /// </summary>
-        public const int Default = 203;
+        public const int DeviceInitialProperty = 203;
     }
 }

--- a/iot-hub/Samples/device/ConventionBasedOperations/Thermostat/Program.cs
+++ b/iot-hub/Samples/device/ConventionBasedOperations/Thermostat/Program.cs
@@ -137,7 +137,6 @@ namespace Microsoft.Azure.Devices.Client.Samples
 
         // Initialize the device client instance using connection string based authentication, over Mqtt protocol (TCP, with fallback over Websocket)
         // and setting the ModelId into ClientOptions.
-        // This method also sets a connection status change callback, that will get triggered any time the device's connection status changes.
         private static DeviceClient InitializeDeviceClient(string deviceConnectionString)
         {
             var options = new ClientOptions
@@ -151,7 +150,6 @@ namespace Microsoft.Azure.Devices.Client.Samples
         }
 
         // Initialize the device client instance using symmetric key based authentication, over Mqtt protocol (TCP, with fallback over Websocket) and setting the ModelId into ClientOptions.
-        // This method also sets a connection status change callback, that will get triggered any time the device's connection status changes.
         private static DeviceClient InitializeDeviceClient(string hostname, IAuthenticationMethod authenticationMethod)
         {
             var options = new ClientOptions

--- a/iot-hub/Samples/device/ConventionBasedOperations/Thermostat/ThermostatSample.cs
+++ b/iot-hub/Samples/device/ConventionBasedOperations/Thermostat/ThermostatSample.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
     public class ThermostatSample
     {
         // The default reported "value".
-        private const double defaultPropertyValue = 0d;
+        private const double DefaultPropertyValue = 0d;
 
         private static readonly Random s_random = new Random();
         private static readonly TimeSpan s_sleepDuration = TimeSpan.FromSeconds(5);
@@ -95,7 +95,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
             if (!writableProperties.Contains("targetTemperature"))
             {
                 // Update the reported property "targetTemperature" with the default values and ACK when the writable properties are empty.
-                await UpdateReportedPropertiesWhenWritablePropertiesEmptyAsync(cancellationToken);
+                await UpdateForEmptyWritableProperty(cancellationToken);
             }
 
             // Check if the writable property version is outdated on the local side.
@@ -287,15 +287,16 @@ namespace Microsoft.Azure.Devices.Client.Samples
             return Math.Round(s_random.NextDouble() * (max - min) + min, 1);
         }
 
-        private async Task UpdateReportedPropertiesWhenWritablePropertiesEmptyAsync(CancellationToken cancellationToken)
+        private async Task UpdateForEmptyWritableProperty(CancellationToken cancellationToken)
         {
             const string propertyName = "targetTemperature";
 
             var reportedProperties = new ClientPropertyCollection();
 
-            // If the writable properties are empty, report the default value with ACK(ac=203, av=0).
+            // If the writable properties are empty, report the default value with ACK(ac=203, av=0) as part of the PnP convention.
+            // "DefaultPropertyValue" is set from the device when the desired property is not set via the hub.
             var propertyValue = _deviceClient.PayloadConvention.PayloadSerializer.CreateWritablePropertyResponse(
-                defaultPropertyValue, 203, 0);
+                DefaultPropertyValue, 203, 0);
 
             reportedProperties.AddRootProperty(propertyName, propertyValue);
 

--- a/iot-hub/Samples/device/ConventionBasedOperations/Thermostat/ThermostatSample.cs
+++ b/iot-hub/Samples/device/ConventionBasedOperations/Thermostat/ThermostatSample.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
             if (!writableProperties.Contains("targetTemperature"))
             {
                 // Update the reported property "targetTemperature" with the default values and ACK when the writable properties are empty.
-                await UpdateForEmptyWritableProperty(cancellationToken);
+                await UpdateForEmptyWritableProperty("targetTemperature", cancellationToken);
             }
 
             // Check if the writable property version is outdated on the local side.
@@ -287,10 +287,8 @@ namespace Microsoft.Azure.Devices.Client.Samples
             return Math.Round(s_random.NextDouble() * (max - min) + min, 1);
         }
 
-        private async Task UpdateForEmptyWritableProperty(CancellationToken cancellationToken)
+        private async Task UpdateForEmptyWritableProperty(string propertyName, CancellationToken cancellationToken)
         {
-            const string propertyName = "targetTemperature";
-
             var reportedProperties = new ClientPropertyCollection();
 
             // If the writable properties are empty, report the default value with ACK(ac=203, av=0) as part of the PnP convention.

--- a/iot-hub/Samples/device/ConventionBasedOperations/Thermostat/ThermostatSample.cs
+++ b/iot-hub/Samples/device/ConventionBasedOperations/Thermostat/ThermostatSample.cs
@@ -14,9 +14,8 @@ namespace Microsoft.Azure.Devices.Client.Samples
 {
     public class ThermostatSample
     {
-        // The default reported "value" and "ad".
+        // The default reported "value".
         private const double defaultPropertyValue = 0d;
-        private const string defaultAckDescription = "Property set from the device without desired";
 
         private static readonly Random s_random = new Random();
         private static readonly TimeSpan s_sleepDuration = TimeSpan.FromSeconds(5);
@@ -295,14 +294,13 @@ namespace Microsoft.Azure.Devices.Client.Samples
 
             // If the writable properties are empty, report the default value with ACK(ac=203, av=0).
             var propertyValue = _deviceClient.PayloadConvention.PayloadSerializer.CreateWritablePropertyResponse(
-                defaultPropertyValue, 203, 
-                0, defaultAckDescription);
+                defaultPropertyValue, 203, 0);
 
             reportedProperties.AddRootProperty(propertyName, propertyValue);
 
             ClientPropertiesUpdateResponse updateResponse = await _deviceClient.UpdateClientPropertiesAsync(reportedProperties);
 
-            _logger.LogDebug($"Property: Update - {reportedProperties.GetSerializedString()} is {nameof(CommonClientResponseCodes.OK)} " +
+            _logger.LogDebug($"Report the default values.\nProperty: Update - {reportedProperties.GetSerializedString()} is {nameof(CommonClientResponseCodes.OK)} " +
                 $"with a version of {updateResponse.Version}.");
         }
     }

--- a/iot-hub/Samples/device/ConventionBasedOperations/Thermostat/ThermostatSample.cs
+++ b/iot-hub/Samples/device/ConventionBasedOperations/Thermostat/ThermostatSample.cs
@@ -94,6 +94,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
 
             if (!writableProperties.Contains("targetTemperature"))
             {
+                // Update the reported property "targetTemperature" with the default values and ACK when the writable properties are empty.
                 await UpdateReportedPropertiesWhenWritablePropertiesEmptyAsync(cancellationToken);
             }
 

--- a/iot-hub/Samples/device/ConventionBasedOperations/Thermostat/ThermostatSample.cs
+++ b/iot-hub/Samples/device/ConventionBasedOperations/Thermostat/ThermostatSample.cs
@@ -293,18 +293,18 @@ namespace Microsoft.Azure.Devices.Client.Samples
             // Check if the device properties are empty.
             if (!writableProperty.Contains(TargetTemperatureProperty) && !reportedProperty.Contains(TargetTemperatureProperty))
             {
-                await ReportDefault(TargetTemperatureProperty, cancellationToken);
+                await ReportInitialProperty(TargetTemperatureProperty, cancellationToken);
             }
         }
 
-        private async Task ReportDefault(string propertyName, CancellationToken cancellationToken)
+        private async Task ReportInitialProperty(string propertyName, CancellationToken cancellationToken)
         {
             var reportedProperties = new ClientPropertyCollection();
 
             // Report the default value with ACK(ac=203, av=0) as part of the PnP convention.
             // "DefaultPropertyValue" is set from the device when the desired property is not set via the hub.
             var propertyValue = _deviceClient.PayloadConvention.PayloadSerializer.CreateWritablePropertyResponse(
-                DefaultPropertyValue, ClientResponseCodes.Default, 0, DefaultACKDescription);
+                DefaultPropertyValue, ClientResponseCodes.DeviceInitialProperty, 0, DefaultACKDescription);
 
             reportedProperties.AddRootProperty(propertyName, propertyValue);
 

--- a/iot-hub/Samples/device/ConventionBasedOperations/Thermostat/ThermostatSample.cs
+++ b/iot-hub/Samples/device/ConventionBasedOperations/Thermostat/ThermostatSample.cs
@@ -13,9 +13,11 @@ namespace Microsoft.Azure.Devices.Client.Samples
 {
     public class ThermostatSample
     {
-        // The default reported "value" and "ad" on the client initial startup.
+        // The default reported "value", "ad" and "av" on the client initial startup.
+        // See https://docs.microsoft.com/en-us/azure/iot-develop/concepts-convention#writable-properties for more details in acknowledgment responses.
         private const double DefaultPropertyValue = 0d;
         private const string DefaultACKDescription = "Initialized with default value";
+        private const long DefaultACKVersion = 0L;
 
         private const string TargetTemperatureProperty = "targetTemperature";
 
@@ -304,7 +306,10 @@ namespace Microsoft.Azure.Devices.Client.Samples
             // Report the default value with ACK(ac=203, av=0) as part of the PnP convention.
             // "DefaultPropertyValue" is set from the device when the desired property is not set via the hub.
             var propertyValue = _deviceClient.PayloadConvention.PayloadSerializer.CreateWritablePropertyResponse(
-                DefaultPropertyValue, ClientResponseCodes.DeviceInitialProperty, 0, DefaultACKDescription);
+                DefaultPropertyValue, 
+                ClientResponseCodes.DeviceInitialProperty, 
+                DefaultACKVersion, 
+                DefaultACKDescription);
 
             reportedProperties.AddRootProperty(propertyName, propertyValue);
 

--- a/iot-hub/Samples/device/ConventionBasedOperations/Thermostat/ThermostatSample.cs
+++ b/iot-hub/Samples/device/ConventionBasedOperations/Thermostat/ThermostatSample.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.Devices.Shared;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 
@@ -14,21 +13,11 @@ namespace Microsoft.Azure.Devices.Client.Samples
 {
     public class ThermostatSample
     {
-        // The specific response codes in this sample.
-        public class ClientResponseCodes : CommonClientResponseCodes
-        {
-            /// <summary>
-            /// This code does not comply with HTTP semantics. Instead, it indicates that the device client
-            /// reports the default value with ACK when its properties are empty.
-            /// </summary>
-            public const int Default = 203;
-        }
-        
         // The default reported "value" and "ad" on the client initial startup.
         private const double DefaultPropertyValue = 0d;
         private const string DefaultACKDescription = "Initialized with default value";
 
-        private const string SamplePropertyName = "targetTemperature";
+        private const string TargetTemperatureProperty = "targetTemperature";
 
         private static readonly Random s_random = new Random();
         private static readonly TimeSpan s_sleepDuration = TimeSpan.FromSeconds(5);
@@ -117,15 +106,15 @@ namespace Microsoft.Azure.Devices.Client.Samples
 
                 foreach (KeyValuePair<string, object> writableProperty in writableProperties)
                 {
-                    if (writableProperty.Key == SamplePropertyName)
+                    if (writableProperty.Key == TargetTemperatureProperty)
                     {
                         // The SubscribeToWritablePropertyUpdateRequestsAsync callback makes the writable property requests available as a
                         // WritableClientProperty, which provides convenience methods for acknowledging the requests. Since property
                         // update requests that were potentially lost during reconnection can be retrieved only as a collection of property
                         // values, and not as a collection of WritableClientProperty, we will need to create the property response ack by ourselves.
-                        if (writableProperties.TryGetValue(SamplePropertyName, out double targetTemperatureValue))
+                        if (writableProperties.TryGetValue(TargetTemperatureProperty, out double targetTemperatureValue))
                         {
-                            _logger.LogDebug($"Property: Received - [ \"{SamplePropertyName}\": {writableProperty}°C ].");
+                            _logger.LogDebug($"Property: Received - [ \"{TargetTemperatureProperty}\": {writableProperty}°C ].");
 
                             _temperature = targetTemperatureValue;
 
@@ -138,7 +127,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
                                 "Reached target temperature");
 
                             var reportedProperty = new ClientPropertyCollection();
-                            reportedProperty.AddRootProperty(SamplePropertyName, propertyValue);
+                            reportedProperty.AddRootProperty(TargetTemperatureProperty, propertyValue);
 
                             ClientPropertiesUpdateResponse updateResponse = await _deviceClient.UpdateClientPropertiesAsync(reportedProperty);
 
@@ -164,16 +153,16 @@ namespace Microsoft.Azure.Devices.Client.Samples
             {
                 switch (writableProperty.Key)
                 {
-                    case SamplePropertyName:
-                        if (writableProperties.TryGetValue(SamplePropertyName, out WritableClientProperty targetTemperatureRequested))
+                    case TargetTemperatureProperty:
+                        if (writableProperties.TryGetValue(TargetTemperatureProperty, out WritableClientProperty targetTemperatureRequested))
                         {
                             double targetTemperatureValue = Convert.ToDouble(targetTemperatureRequested.Value);
-                            _logger.LogDebug($"Property: Received - [ \"{SamplePropertyName}\": {targetTemperatureRequested.Value}°C ].");
+                            _logger.LogDebug($"Property: Received - [ \"{TargetTemperatureProperty}\": {targetTemperatureRequested.Value}°C ].");
 
                             _temperature = targetTemperatureValue;
 
                             var reportedProperty = new ClientPropertyCollection();
-                            reportedProperty.AddRootProperty(SamplePropertyName, targetTemperatureRequested.AcknowledgeWith(ClientResponseCodes.OK, "Reached target temperature"));
+                            reportedProperty.AddRootProperty(TargetTemperatureProperty, targetTemperatureRequested.AcknowledgeWith(ClientResponseCodes.OK, "Reached target temperature"));
 
                             ClientPropertiesUpdateResponse updateResponse = await _deviceClient.UpdateClientPropertiesAsync(reportedProperty);
 
@@ -302,9 +291,9 @@ namespace Microsoft.Azure.Devices.Client.Samples
             ClientPropertyCollection reportedProperty = properties.ReportedFromClient;
 
             // Check if the device properties are empty.
-            if (!writableProperty.Contains(SamplePropertyName) && !reportedProperty.Contains(SamplePropertyName))
+            if (!writableProperty.Contains(TargetTemperatureProperty) && !reportedProperty.Contains(TargetTemperatureProperty))
             {
-                await ReportDefault(SamplePropertyName, cancellationToken);
+                await ReportDefault(TargetTemperatureProperty, cancellationToken);
             }
         }
 


### PR DESCRIPTION
Report properties with the default value and ACK when the device properties are empty.