### PR TITLE
Update PnpDeviceSamples Sample

### DIFF
--- a/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController/Program.cs
+++ b/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController/Program.cs
@@ -138,8 +138,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
         }
 
         // Initialize the device client instance using connection string based authentication, over Mqtt protocol (TCP, with fallback over Websocket) and
-        // setting the ModelId into ClientOptions.This method also sets a connection status change callback, that will get triggered any time the device's
-        // connection status changes.
+        // setting the ModelId into ClientOptions.
         private static DeviceClient InitializeDeviceClient(string deviceConnectionString)
         {
             var options = new ClientOptions
@@ -153,7 +152,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
         }
 
         // Initialize the device client instance using symmetric key based authentication, over Mqtt protocol (TCP, with fallback over Websocket)
-        // and setting the ModelId into ClientOptions. This method also sets a connection status change callback, that will get triggered any time the device's connection status changes.
+        // and setting the ModelId into ClientOptions.
         private static DeviceClient InitializeDeviceClient(string hostname, IAuthenticationMethod authenticationMethod)
         {
             var options = new ClientOptions

--- a/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController/TemperatureControllerSample.cs
+++ b/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController/TemperatureControllerSample.cs
@@ -19,13 +19,19 @@ namespace Microsoft.Azure.Devices.Client.Samples
     {
         Completed = 200,
         InProgress = 202,
-        Default = 203,
+        DeviceInitialProperty = 203,
         BadRequest = 400,
         NotFound = 404
     }
 
     public class TemperatureControllerSample
     {
+        // The default reported "value" and "av" for each "Thermostat" component on the client initial startup.
+        private const double DefaultPropertyValue = 0d;
+        private const long DefaultACKVersion = 0L;
+
+        private const string TargetTemperatureProperty = "targetTemperature";
+
         private const string Thermostat1 = "thermostat1";
         private const string Thermostat2 = "thermostat2";
         private const string SerialNumber = "SR-123456";
@@ -72,6 +78,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
             // -> Set handler to receive "reboot" command - root interface.
             // -> Set handler to receive "getMaxMinReport" command - on "Thermostat" components.
             // -> Set handler to receive "targetTemperature" property updates from service - on "Thermostat" components.
+            // -> Check if the properties are empty on the initial startup - for each "Thermostat" component. If so, report the default values with ACK to the hub.
             // -> Update device information on "deviceInformation" component.
             // -> Send initial device info - "workingSet" over telemetry, "serialNumber" over reported property update - root interface.
             // -> Periodically send "temperature" over telemetry - on "Thermostat" components.
@@ -101,6 +108,10 @@ namespace Microsoft.Azure.Devices.Client.Samples
             await _deviceClient.SetDesiredPropertyUpdateCallbackAsync(SetDesiredPropertyUpdateCallback, null, cancellationToken);
             _desiredPropertyUpdateCallbacks.Add(Thermostat1, TargetTemperatureUpdateCallbackAsync);
             _desiredPropertyUpdateCallbacks.Add(Thermostat2, TargetTemperatureUpdateCallbackAsync);
+
+            _logger.LogDebug("For each component, check if the device properties are empty on the initial startup.");
+            await CheckEmptyProperties(Thermostat1, cancellationToken);
+            await CheckEmptyProperties(Thermostat2, cancellationToken);
 
             await UpdateDeviceInformationAsync(cancellationToken);
             await SendDeviceSerialNumberAsync(cancellationToken);
@@ -134,22 +145,6 @@ namespace Microsoft.Azure.Devices.Client.Samples
 
             TwinCollection twinCollection = twin.Properties.Desired;
             long serverWritablePropertiesVersion = twinCollection.Version;
-
-            if (!twinCollection.Contains(Thermostat1))
-            {
-                // Update the reported property "targetTemperature" with the default values and ACK
-                // for the component "thermostat1" when its writable properties are empty.
-                // This is a component-level property update call.
-                await RespondToEmptyWritableProperty(Thermostat1, cancellationToken);
-            }
-
-            if (!twinCollection.Contains(Thermostat2))
-            {
-                // Update the reported property "targetTemperature" with the default values and ACK
-                // for the component "thermostat2" when its writable properties are empty.
-                // This is a component-level property update call.
-                await RespondToEmptyWritableProperty(Thermostat2, cancellationToken);
-            }
 
             // Check if the writable property version is outdated on the local side.
             // For the purpose of this sample, we'll only check the writable property versions between local and server
@@ -292,12 +287,11 @@ namespace Microsoft.Azure.Devices.Client.Samples
         // and updates the current temperature value over telemetry and property update.
         private async Task TargetTemperatureUpdateCallbackAsync(TwinCollection desiredProperties, object userContext)
         {
-            const string propertyName = "targetTemperature";
             string componentName = (string)userContext;
 
             bool targetTempUpdateReceived = PnpConvention.TryGetPropertyFromTwin(
                 desiredProperties,
-                propertyName,
+                TargetTemperatureProperty,
                 out double targetTemperature,
                 componentName);
             if (!targetTempUpdateReceived)
@@ -306,19 +300,20 @@ namespace Microsoft.Azure.Devices.Client.Samples
                 return;
             }
 
-            _logger.LogDebug($"Property: Received - component=\"{componentName}\", {{ \"{propertyName}\": {targetTemperature}°C }}.");
+            _logger.LogDebug($"Property: Received - component=\"{componentName}\", {{ \"{TargetTemperatureProperty}\": {targetTemperature}°C }}.");
 
             s_localWritablePropertiesVersion = desiredProperties.Version;
 
             TwinCollection pendingReportedProperty = PnpConvention.CreateComponentWritablePropertyResponse(
                 componentName,
-                propertyName,
+                TargetTemperatureProperty,
                 targetTemperature,
                 (int)StatusCode.InProgress,
-                desiredProperties.Version);
+                desiredProperties.Version,
+                "In-progress - reporting current temperature");
 
             await _deviceClient.UpdateReportedPropertiesAsync(pendingReportedProperty);
-            _logger.LogDebug($"Property: Update - component=\"{componentName}\", {{\"{propertyName}\": {targetTemperature} }} in °C is {StatusCode.InProgress}.");
+            _logger.LogDebug($"Property: Update - component=\"{componentName}\", {{\"{TargetTemperatureProperty}\": {targetTemperature} }} in °C is {StatusCode.InProgress}.");
 
             // Update Temperature in 2 steps
             double step = (targetTemperature - _temperature[componentName]) / 2d;
@@ -330,14 +325,14 @@ namespace Microsoft.Azure.Devices.Client.Samples
 
             TwinCollection completedReportedProperty = PnpConvention.CreateComponentWritablePropertyResponse(
                 componentName,
-                propertyName,
+                TargetTemperatureProperty,
                 _temperature[componentName],
                 (int)StatusCode.Completed,
                 desiredProperties.Version,
                 "Successfully updated target temperature");
 
             await _deviceClient.UpdateReportedPropertiesAsync(completedReportedProperty);
-            _logger.LogDebug($"Property: Update - component=\"{componentName}\", {{\"{propertyName}\": {_temperature[componentName]} }} in °C is {StatusCode.Completed}");
+            _logger.LogDebug($"Property: Update - component=\"{componentName}\", {{\"{TargetTemperatureProperty}\": {_temperature[componentName]} }} in °C is {StatusCode.Completed}");
         }
 
         // Report the property updates on "deviceInformation" component.
@@ -437,16 +432,30 @@ namespace Microsoft.Azure.Devices.Client.Samples
             _logger.LogDebug($"Property: Update - component=\"{componentName}\", {{ \"{propertyName}\": {maxTemp} }} in °C is complete.");
         }
 
-        private async Task RespondToEmptyWritableProperty(string componentName, CancellationToken cancellationToken)
+        private async Task CheckEmptyProperties(string componentName, CancellationToken cancellationToken)
         {
-            const string propertyName = "targetTemperature";
-            const double defaultPropertyValue = 0d;
-            const long defaultVersion = 0L;
+            Twin twin = await _deviceClient.GetTwinAsync();
+            TwinCollection writableProperty = twin.Properties.Desired;
+            TwinCollection reportedProperty = twin.Properties.Reported;
 
-            // If the writable properties are empty, report the default value with ACK(ac=203, av=0) as part of the PnP convention.
+            // Check if the device properties (both writable and reported) for the current component are empty.
+            if (!writableProperty.Contains(componentName) && !reportedProperty.Contains(componentName))
+            {
+                await ReportInitialProperty(componentName, TargetTemperatureProperty, cancellationToken);
+            }
+        }
+
+        private async Task ReportInitialProperty(string componentName, string propertyName, CancellationToken cancellationToken)
+        {
+            // If the device properties are empty, report the default value with ACK(ac=203, av=0) as part of the PnP convention.
             // "DefaultPropertyValue" is set from the device when the desired property is not set via the hub.
-            TwinCollection reportedProperties = 
-                PnpConvention.CreateComponentWritablePropertyResponse(componentName, propertyName, defaultPropertyValue, (int)StatusCode.Default, defaultVersion);
+            TwinCollection reportedProperties = PnpConvention.CreateComponentWritablePropertyResponse(
+                componentName, 
+                propertyName, 
+                DefaultPropertyValue, 
+                (int)StatusCode.DeviceInitialProperty, 
+                DefaultACKVersion,
+                "Initialized with default value");
 
             await _deviceClient.UpdateReportedPropertiesAsync(reportedProperties, cancellationToken);
 

--- a/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController/TemperatureControllerSample.cs
+++ b/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController/TemperatureControllerSample.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
                 // This can get back "lost" property updates in a device reconnection from status Disconnected_Retrying or Disconnected.
                 if (status == ConnectionStatus.Connected)
                 {
-                    await GetWritablePropertiesAndHandleChangesAsync(cancellationToken);
+                    await GetWritablePropertiesAndHandleChangesAsync();
                 }
             });
             
@@ -138,7 +138,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
             }
         }
 
-        private async Task GetWritablePropertiesAndHandleChangesAsync(CancellationToken cancellationToken)
+        private async Task GetWritablePropertiesAndHandleChangesAsync()
         {
             Twin twin = await _deviceClient.GetTwinAsync();
             _logger.LogInformation($"Device retrieving twin values on CONNECT: {twin.ToJson()}");

--- a/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController/TemperatureControllerSample.cs
+++ b/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController/TemperatureControllerSample.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
     {
         Completed = 200,
         InProgress = 202,
-        DeviceInitialProperty = 203,
+        ReportDeviceInitialProperty = 203,
         BadRequest = 400,
         NotFound = 404
     }
@@ -27,9 +27,9 @@ namespace Microsoft.Azure.Devices.Client.Samples
     public class TemperatureControllerSample
     {
         // The default reported "value" and "av" for each "Thermostat" component on the client initial startup.
-        // See https://docs.microsoft.com/en-us/azure/iot-develop/concepts-convention#writable-properties for more details in acknowledgment responses.
+        // See https://docs.microsoft.com/azure/iot-develop/concepts-convention#writable-properties for more details in acknowledgment responses.
         private const double DefaultPropertyValue = 0d;
-        private const long DefaultACKVersion = 0L;
+        private const long DefaultAckVersion = 0L;
 
         private const string TargetTemperatureProperty = "targetTemperature";
 
@@ -111,8 +111,8 @@ namespace Microsoft.Azure.Devices.Client.Samples
             _desiredPropertyUpdateCallbacks.Add(Thermostat2, TargetTemperatureUpdateCallbackAsync);
 
             _logger.LogDebug("For each component, check if the device properties are empty on the initial startup.");
-            await CheckEmptyProperties(Thermostat1, cancellationToken);
-            await CheckEmptyProperties(Thermostat2, cancellationToken);
+            await CheckEmptyPropertiesAsync(Thermostat1, cancellationToken);
+            await CheckEmptyPropertiesAsync(Thermostat2, cancellationToken);
 
             await UpdateDeviceInformationAsync(cancellationToken);
             await SendDeviceSerialNumberAsync(cancellationToken);
@@ -311,7 +311,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
                 targetTemperature,
                 (int)StatusCode.InProgress,
                 desiredProperties.Version,
-                "In-progress - reporting current temperature");
+                "In progress - reporting current temperature");
 
             await _deviceClient.UpdateReportedPropertiesAsync(pendingReportedProperty);
             _logger.LogDebug($"Property: Update - component=\"{componentName}\", {{\"{TargetTemperatureProperty}\": {targetTemperature} }} in °C is {StatusCode.InProgress}.");
@@ -433,7 +433,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
             _logger.LogDebug($"Property: Update - component=\"{componentName}\", {{ \"{propertyName}\": {maxTemp} }} in °C is complete.");
         }
 
-        private async Task CheckEmptyProperties(string componentName, CancellationToken cancellationToken)
+        private async Task CheckEmptyPropertiesAsync(string componentName, CancellationToken cancellationToken)
         {
             Twin twin = await _deviceClient.GetTwinAsync();
             TwinCollection writableProperty = twin.Properties.Desired;
@@ -442,11 +442,11 @@ namespace Microsoft.Azure.Devices.Client.Samples
             // Check if the device properties (both writable and reported) for the current component are empty.
             if (!writableProperty.Contains(componentName) && !reportedProperty.Contains(componentName))
             {
-                await ReportInitialProperty(componentName, TargetTemperatureProperty, cancellationToken);
+                await ReportInitialPropertyAsync(componentName, TargetTemperatureProperty, cancellationToken);
             }
         }
 
-        private async Task ReportInitialProperty(string componentName, string propertyName, CancellationToken cancellationToken)
+        private async Task ReportInitialPropertyAsync(string componentName, string propertyName, CancellationToken cancellationToken)
         {
             // If the device properties are empty, report the default value with ACK(ac=203, av=0) as part of the PnP convention.
             // "DefaultPropertyValue" is set from the device when the desired property is not set via the hub.
@@ -454,8 +454,8 @@ namespace Microsoft.Azure.Devices.Client.Samples
                 componentName, 
                 propertyName, 
                 DefaultPropertyValue, 
-                (int)StatusCode.DeviceInitialProperty, 
-                DefaultACKVersion,
+                (int)StatusCode.ReportDeviceInitialProperty, 
+                DefaultAckVersion,
                 "Initialized with default value");
 
             await _deviceClient.UpdateReportedPropertiesAsync(reportedProperties, cancellationToken);

--- a/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController/TemperatureControllerSample.cs
+++ b/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController/TemperatureControllerSample.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
     public class TemperatureControllerSample
     {
         // The default reported "value" and "av" for each "Thermostat" component on the client initial startup.
+        // See https://docs.microsoft.com/en-us/azure/iot-develop/concepts-convention#writable-properties for more details in acknowledgment responses.
         private const double DefaultPropertyValue = 0d;
         private const long DefaultACKVersion = 0L;
 

--- a/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController/TemperatureControllerSample.cs
+++ b/iot-hub/Samples/device/PnpDeviceSamples/TemperatureController/TemperatureControllerSample.cs
@@ -19,8 +19,9 @@ namespace Microsoft.Azure.Devices.Client.Samples
     {
         Completed = 200,
         InProgress = 202,
-        NotFound = 404,
-        BadRequest = 400
+        Default = 203,
+        BadRequest = 400,
+        NotFound = 404
     }
 
     public class TemperatureControllerSample
@@ -84,7 +85,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
                 // This can get back "lost" property updates in a device reconnection from status Disconnected_Retrying or Disconnected.
                 if (status == ConnectionStatus.Connected)
                 {
-                    await GetWritablePropertiesAndHandleChangesAsync();
+                    await GetWritablePropertiesAndHandleChangesAsync(cancellationToken);
                 }
             });
             
@@ -126,13 +127,29 @@ namespace Microsoft.Azure.Devices.Client.Samples
             }
         }
 
-        private async Task GetWritablePropertiesAndHandleChangesAsync()
+        private async Task GetWritablePropertiesAndHandleChangesAsync(CancellationToken cancellationToken)
         {
             Twin twin = await _deviceClient.GetTwinAsync();
             _logger.LogInformation($"Device retrieving twin values on CONNECT: {twin.ToJson()}");
 
             TwinCollection twinCollection = twin.Properties.Desired;
             long serverWritablePropertiesVersion = twinCollection.Version;
+
+            if (!twinCollection.Contains(Thermostat1))
+            {
+                // Update the reported property "targetTemperature" with the default values and ACK
+                // for the component "thermostat1" when its writable properties are empty.
+                // This is a component-level property update call.
+                await RespondToEmptyWritableProperty(Thermostat1, cancellationToken);
+            }
+
+            if (!twinCollection.Contains(Thermostat2))
+            {
+                // Update the reported property "targetTemperature" with the default values and ACK
+                // for the component "thermostat2" when its writable properties are empty.
+                // This is a component-level property update call.
+                await RespondToEmptyWritableProperty(Thermostat2, cancellationToken);
+            }
 
             // Check if the writable property version is outdated on the local side.
             // For the purpose of this sample, we'll only check the writable property versions between local and server
@@ -418,6 +435,22 @@ namespace Microsoft.Azure.Devices.Client.Samples
 
             await _deviceClient.UpdateReportedPropertiesAsync(reportedProperties, cancellationToken);
             _logger.LogDebug($"Property: Update - component=\"{componentName}\", {{ \"{propertyName}\": {maxTemp} }} in °C is complete.");
+        }
+
+        private async Task RespondToEmptyWritableProperty(string componentName, CancellationToken cancellationToken)
+        {
+            const string propertyName = "targetTemperature";
+            const double defaultPropertyValue = 0d;
+            const long defaultVersion = 0L;
+
+            // If the writable properties are empty, report the default value with ACK(ac=203, av=0) as part of the PnP convention.
+            // "DefaultPropertyValue" is set from the device when the desired property is not set via the hub.
+            TwinCollection reportedProperties = 
+                PnpConvention.CreateComponentWritablePropertyResponse(componentName, propertyName, defaultPropertyValue, (int)StatusCode.Default, defaultVersion);
+
+            await _deviceClient.UpdateReportedPropertiesAsync(reportedProperties, cancellationToken);
+
+            _logger.LogDebug($"Report the default values for \"{componentName}\".\nProperty: Update - {reportedProperties.ToJson()} is complete.");
         }
     }
 }

--- a/iot-hub/Samples/device/PnpDeviceSamples/Thermostat/Program.cs
+++ b/iot-hub/Samples/device/PnpDeviceSamples/Thermostat/Program.cs
@@ -137,7 +137,6 @@ namespace Microsoft.Azure.Devices.Client.Samples
 
         // Initialize the device client instance using connection string based authentication, over Mqtt protocol (TCP, with fallback over Websocket)
         // and setting the ModelId into ClientOptions.
-        // This method also sets a connection status change callback, that will get triggered any time the device's connection status changes.
         private static DeviceClient InitializeDeviceClient(string deviceConnectionString)
         {
             var options = new ClientOptions
@@ -151,7 +150,6 @@ namespace Microsoft.Azure.Devices.Client.Samples
         }
 
         // Initialize the device client instance using symmetric key based authentication, over Mqtt protocol (TCP, with fallback over Websocket) and setting the ModelId into ClientOptions.
-        // This method also sets a connection status change callback, that will get triggered any time the device's connection status changes.
         private static DeviceClient InitializeDeviceClient(string hostname, IAuthenticationMethod authenticationMethod)
         {
             var options = new ClientOptions

--- a/iot-hub/Samples/device/PnpDeviceSamples/Thermostat/Thermostat.csproj
+++ b/iot-hub/Samples/device/PnpDeviceSamples/Thermostat/Thermostat.csproj
@@ -20,10 +20,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\PnpConvention\PnpHelpers.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\..\..\..\helpers\ColorConsoleLogger\ColorConsoleLogger.csproj" />
   </ItemGroup>
 

--- a/iot-hub/Samples/device/PnpDeviceSamples/Thermostat/Thermostat.csproj
+++ b/iot-hub/Samples/device/PnpDeviceSamples/Thermostat/Thermostat.csproj
@@ -20,6 +20,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\PnpConvention\PnpHelpers.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\..\..\..\helpers\ColorConsoleLogger\ColorConsoleLogger.csproj" />
   </ItemGroup>
 

--- a/iot-hub/Samples/device/PnpDeviceSamples/Thermostat/ThermostatSample.cs
+++ b/iot-hub/Samples/device/PnpDeviceSamples/Thermostat/ThermostatSample.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
     public class ThermostatSample
     {
         // The default reported "value" and "av" for each "Thermostat" component on the client initial startup.
+        // See https://docs.microsoft.com/en-us/azure/iot-develop/concepts-convention#writable-properties for more details in acknowledgment responses.
         private const double DefaultPropertyValue = 0d;
         private const long DefaultACKVersion = 0L;
 
@@ -120,10 +121,10 @@ namespace Microsoft.Azure.Devices.Client.Samples
 
                 foreach (KeyValuePair<string, object> propertyUpdate in twinCollection)
                 {
-                    string componentName = propertyUpdate.Key;
-                    if (componentName == TargetTemperatureProperty)
+                    string propertyName = propertyUpdate.Key;
+                    if (propertyName == TargetTemperatureProperty)
                     {
-                        await TargetTemperatureUpdateCallbackAsync(twinCollection, componentName);
+                        await TargetTemperatureUpdateCallbackAsync(twinCollection, propertyName);
                     }
                     else
                     {

--- a/iot-hub/Samples/device/PnpDeviceSamples/Thermostat/ThermostatSample.cs
+++ b/iot-hub/Samples/device/PnpDeviceSamples/Thermostat/ThermostatSample.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
                 // This can get back "lost" property updates in a device reconnection from status Disconnected_Retrying or Disconnected.
                 if (status == ConnectionStatus.Connected)
                 {
-                    await GetWritablePropertiesAndHandleChangesAsync(cancellationToken);
+                    await GetWritablePropertiesAndHandleChangesAsync();
                 }
             });
 
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.Devices.Client.Samples
             }
         }
 
-        private async Task GetWritablePropertiesAndHandleChangesAsync(CancellationToken cancellationToken)
+        private async Task GetWritablePropertiesAndHandleChangesAsync()
         {
             Twin twin = await _deviceClient.GetTwinAsync();
             _logger.LogInformation($"Device retrieving twin values on CONNECT: {twin.ToJson()}");


### PR DESCRIPTION
Per the updated Pnp convention [here](https://docs.microsoft.com/en-us/azure/iot-develop/concepts-convention#writable-properties), report properties with the default value and ACK when the device properties are empty.

Similar to [this](https://github.com/Azure-Samples/azure-iot-samples-csharp/pull/267).