### PR TITLE
feat(prov-device): Add sample to demonstrate dps client certificate issuance

### DIFF
--- a/provisioning/Samples/device/ProvisioningDeviceSamples.sln
+++ b/provisioning/Samples/device/ProvisioningDeviceSamples.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31129.286
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32407.343
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TpmSample", "TpmSample\TpmSample.csproj", "{995317C2-9D36-477A-8781-94C1F0C3A87F}"
 EndProject
@@ -11,7 +11,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SecurityProviderTpmSimulato
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SymmetricKeySample", "SymmetricKeySample\SymmetricKeySample.csproj", "{7148297F-B361-43FD-96A8-77305AA2B263}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ComputeDerivedSymmetricKeySample", "ComputeDerivedSymmetricKeySample\ComputeDerivedSymmetricKeySample.csproj", "{3557CC19-72B6-462E-9BF4-E3675D54E67F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ComputeDerivedSymmetricKeySample", "ComputeDerivedSymmetricKeySample\ComputeDerivedSymmetricKeySample.csproj", "{3557CC19-72B6-462E-9BF4-E3675D54E67F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SymmetricKeyWithOperationalCertificateSample", "SymmetricKeyWithOperationalCertificateSample\SymmetricKeyWithOperationalCertificateSample.csproj", "{15D99352-B7F4-4887-AC7F-78C3EAFCD244}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ColorConsoleLogger", "..\..\..\helpers\ColorConsoleLogger\ColorConsoleLogger.csproj", "{B5358F05-5795-4CB8-8ADF-0622FA55929E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -39,6 +43,14 @@ Global
 		{3557CC19-72B6-462E-9BF4-E3675D54E67F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3557CC19-72B6-462E-9BF4-E3675D54E67F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3557CC19-72B6-462E-9BF4-E3675D54E67F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{15D99352-B7F4-4887-AC7F-78C3EAFCD244}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{15D99352-B7F4-4887-AC7F-78C3EAFCD244}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{15D99352-B7F4-4887-AC7F-78C3EAFCD244}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{15D99352-B7F4-4887-AC7F-78C3EAFCD244}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B5358F05-5795-4CB8-8ADF-0622FA55929E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B5358F05-5795-4CB8-8ADF-0622FA55929E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B5358F05-5795-4CB8-8ADF-0622FA55929E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B5358F05-5795-4CB8-8ADF-0622FA55929E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/provisioning/Samples/device/SymmetricKeySample/ProvisioningDeviceClientSample.cs
+++ b/provisioning/Samples/device/SymmetricKeySample/ProvisioningDeviceClientSample.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Samples
             // For individual enrollments, the first parameter must be the registration Id, where in the enrollment
             // the device Id is already chosen. However, for group enrollments the device Id can be requested by
             // the device, as long as the key has been computed using that value.
-            // Also, the secondary could be included, but was left out for the simplicity of this sample.
+            // Also, the secondary key could be included, but was left out for the simplicity of this sample.
             using var security = new SecurityProviderSymmetricKey(
                 _parameters.Id,
                 _parameters.PrimaryKey,

--- a/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/EnrollmentType.cs
+++ b/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/EnrollmentType.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.Devices.Provisioning.Client.Samples
+{
+    /// <summary>
+    /// The type of enrollment for a device in the provisioning service.
+    /// </summary>
+    public enum EnrollmentType
+    {
+        /// <summary>
+        ///  Enrollment for a single device.
+        /// </summary>
+        Individual,
+
+        /// <summary>
+        /// Enrollment for a group of devices.
+        /// </summary>
+        Group,
+    }
+}

--- a/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/Parameters.cs
+++ b/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/Parameters.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using CommandLine;
+using Microsoft.Azure.Devices.Client;
+
+namespace Microsoft.Azure.Devices.Provisioning.Client.Samples
+{
+    /// <summary>
+    /// Parameters for the application
+    /// </summary>
+    internal class Parameters
+    {
+        [Option(
+            's',
+            "IdScope",
+            Required = true,
+            HelpText = "The Id Scope of the DPS instance")]
+        public string IdScope { get; set; }
+
+        [Option(
+            'i',
+            "Id",
+            Required = true,
+            HelpText = "The registration Id when using individual enrollment, or the desired device Id when using group enrollment.")]
+        public string Id { get; set; }
+
+        [Option(
+            'p',
+            "PrimaryKey",
+            Required = true,
+            HelpText = "The primary key of the individual enrollment or the derived primary key of the group enrollment. See the ComputeDerivedSymmetricKeySample for how to generate the derived key.")]
+        public string PrimaryKey { get; set; }
+
+        [Option(
+            'e',
+            "EnrollmentType",
+            Default = EnrollmentType.Individual,
+            HelpText = "The type of enrollment: Individual or Group")]
+        public EnrollmentType EnrollmentType { get; set; }
+
+        [Option(
+            'g',
+            "GlobalDeviceEndpoint",
+            Default = "global.azure-devices-provisioning.net",
+            HelpText = "The global endpoint for devices to connect to.")]
+        public string GlobalDeviceEndpoint { get; set; }
+
+        [Option(
+            't',
+            "TransportType",
+            Default = TransportType.Mqtt,
+            HelpText = "The transport to use to communicate with the device provisioning instance. Possible values include Mqtt, Mqtt_WebSocket_Only, Mqtt_Tcp_Only, Amqp, Amqp_WebSocket_Only, Amqp_Tcp_only, and Http1.")]
+        public TransportType TransportType { get; set; }
+    }
+}

--- a/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/Program.cs
+++ b/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/Program.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using CommandLine;
+using Microsoft.Azure.Devices.Logging;
+using Microsoft.Azure.Devices.Provisioning.Client.Samples;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
+
+namespace SymmetricKeySample
+{
+    /// <summary>
+    /// A sample to illustrate connecting a device to hub using the device provisioning service and a symmetric key.
+    /// </summary>
+    internal class Program
+    {
+        public static async Task<int> Main(string[] args)
+        {
+            // Parse application parameters
+            Parameters parameters = null;
+            ParserResult<Parameters> result = Parser.Default.ParseArguments<Parameters>(args)
+                .WithParsed(parsedParams =>
+                {
+                    parameters = parsedParams;
+                })
+                .WithNotParsed(errors =>
+                {
+                    Environment.Exit(1);
+                });
+
+            // Set up logging
+            ILoggerFactory loggerFactory = new LoggerFactory();
+            loggerFactory.AddColorConsoleLogger(
+                new ColorConsoleLoggerConfiguration
+                {
+                    MinLogLevel = LogLevel.Trace,
+                });
+            var logger = loggerFactory.CreateLogger<Program>();
+
+            const string SdkEventProviderPrefix = "Microsoft-Azure-";
+            // Instantiating this seems to do all we need for outputting SDK events to our console log
+            // The SDK events are written at trace log level.
+            _ = new ConsoleEventListener(SdkEventProviderPrefix, logger);
+
+            var sample = new ProvisioningDeviceClientSample(parameters, logger);
+            await sample.RunSampleAsync();
+
+            return 0;
+        }
+    }
+}

--- a/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/ProvisioningDeviceClientSample.cs
+++ b/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/ProvisioningDeviceClientSample.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Samples
                 // Pass in your certificate signing request along with the registration request.
                 // DPS will forward your signing request to your linked certificate authority (CA).
                 // The CA will sign and return an operational X509 device identity certificate (aka client certificate) to DPS.
-                // DPS will register the device and operational client certificate thumbprint in IoT Hub and return the certificate to the IoT device.
+                // DPS will register the device and operational client certificate thumbprint in IoT hub and return the certificate to the IoT device.
                 // The IoT device can then use the operational certificate to authenticate with IoT Hub.
 
                 var registrationData = new ProvisioningRegistrationAdditionalData

--- a/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/ProvisioningDeviceClientSample.cs
+++ b/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/ProvisioningDeviceClientSample.cs
@@ -32,79 +32,84 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Samples
 
         public async Task RunSampleAsync()
         {
-            // Generate the certificate signing request for requesting X509 onboarding certificate for authenticating with IoT hub.
-            // This sample uses openssl to generate an ECC P-256 keypair and the corresponding certificate signing request.
-            string certificateSigningRequest = GenerateClientCertKeyPairAndCsr(_parameters.Id);
-
-            _logger.LogInformation($"Initializing the device provisioning client...");
-
-            // For individual enrollments, the first parameter must be the registration Id, where in the enrollment
-            // the device Id is already chosen. However, for group enrollments the device Id can be requested by
-            // the device, as long as the key has been computed using that value.
-            // Also, the secondary key could be included, but was left out for the simplicity of this sample.
-            using var security = new SecurityProviderSymmetricKey(
-                _parameters.Id,
-                _parameters.PrimaryKey,
-                null);
-
-            using var transportHandler = GetTransportHandler();
-
-            // Pass in your onboarding credentials when creating your provisioning device client instance.
-            // This credential will be used to authenticate your request with the device provisioning service (DPS).
-            ProvisioningDeviceClient provClient = ProvisioningDeviceClient.Create(
-                _parameters.GlobalDeviceEndpoint,
-                _parameters.IdScope,
-                security,
-                transportHandler);
-
-            _logger.LogInformation($"Initialized for registration Id {security.GetRegistrationID()}.");
-
-            // Pass in your certificate signing request along with the registration request.
-            // DPS will forward your signing request to your linked certificate authority (CA).
-            // The CA will sign and return an operational X509 device identity certificate (aka client certificate) to DPS.
-            // DPS will register the device and operational client certificate thumbprint in IoT Hub and return the certificate to the IoT device.
-            // The IoT device can then use the operational certificate to authenticate with IoT Hub.
-
-            var registrationData = new ProvisioningRegistrationAdditionalData
+            try
             {
-                OperationalCertificateRequest = certificateSigningRequest,
-            };
+                // Generate the certificate signing request for requesting X509 onboarding certificate for authenticating with IoT hub.
+                // This sample uses openssl to generate an ECC P-256 keypair and the corresponding certificate signing request.
+                string certificateSigningRequest = GenerateClientCertKeyPairAndCsr(_parameters.Id);
 
-            _logger.LogInformation("Registering with the device provisioning service...");
-            DeviceRegistrationResult result = await provClient.RegisterAsync(registrationData);
+                _logger.LogInformation($"Initializing the device provisioning client...");
 
-            _logger.LogInformation($"Registration status: {result.Status}.");
-            if (result.Status != ProvisioningRegistrationStatusType.Assigned)
-            {
-                _logger.LogError($"Registration status did not assign a hub, so exiting this sample.");
-                return;
+                // For individual enrollments, the first parameter must be the registration Id, where in the enrollment
+                // the device Id is already chosen. However, for group enrollments the device Id can be requested by
+                // the device, as long as the key has been computed using that value.
+                // Also, the secondary key could be included, but was left out for the simplicity of this sample.
+                using var security = new SecurityProviderSymmetricKey(
+                    _parameters.Id,
+                    _parameters.PrimaryKey,
+                    null);
+
+                using var transportHandler = GetTransportHandler();
+
+                // Pass in your onboarding credentials when creating your provisioning device client instance.
+                // This credential will be used to authenticate your request with the device provisioning service (DPS).
+                ProvisioningDeviceClient provClient = ProvisioningDeviceClient.Create(
+                    _parameters.GlobalDeviceEndpoint,
+                    _parameters.IdScope,
+                    security,
+                    transportHandler);
+
+                _logger.LogInformation($"Initialized for registration Id {security.GetRegistrationID()}.");
+
+                // Pass in your certificate signing request along with the registration request.
+                // DPS will forward your signing request to your linked certificate authority (CA).
+                // The CA will sign and return an operational X509 device identity certificate (aka client certificate) to DPS.
+                // DPS will register the device and operational client certificate thumbprint in IoT Hub and return the certificate to the IoT device.
+                // The IoT device can then use the operational certificate to authenticate with IoT Hub.
+
+                var registrationData = new ProvisioningRegistrationAdditionalData
+                {
+                    OperationalCertificateRequest = certificateSigningRequest,
+                };
+
+                _logger.LogInformation("Registering with the device provisioning service...");
+                DeviceRegistrationResult result = await provClient.RegisterAsync(registrationData);
+
+                _logger.LogInformation($"Registration status: {result.Status}.");
+                if (result.Status != ProvisioningRegistrationStatusType.Assigned)
+                {
+                    _logger.LogError($"Registration status did not assign a hub, so exiting this sample.");
+                    return;
+                }
+
+                _logger.LogInformation($"Device {result.DeviceId} registered to {result.AssignedHub}.");
+
+                if (result.IssuedClientCertificate == null)
+                {
+                    _logger.LogError($"Expected operational certificate was not returned by DPS, so exiting this sample.");
+                    return;
+                }
+
+                // This sample uses openssl to generate the pfx certificate from the issued operational certificate and the previously created ECC P-256 keypair.
+                // This certificate will be used when authneticating with IoT hub.
+                _logger.LogInformation("Creating an X509 certificate from the issued operational certificate...");
+                using X509Certificate2 clientCertificate = GenerateOperationalCertificateFromIssuedCertificate(result.RegistrationId, result.IssuedClientCertificate);
+                IAuthenticationMethod auth = new DeviceAuthenticationWithX509Certificate(result.DeviceId, clientCertificate);
+
+                _logger.LogInformation($"Testing the provisioned device with IoT Hub...");
+                using DeviceClient iotClient = DeviceClient.Create(result.AssignedHub, auth, _parameters.TransportType);
+
+                _logger.LogInformation("Sending a telemetry message...");
+                using var message = new Message(Encoding.UTF8.GetBytes("TestMessage"));
+                await iotClient.SendEventAsync(message);
+                await iotClient.CloseAsync();
             }
-
-            _logger.LogInformation($"Device {result.DeviceId} registered to {result.AssignedHub}.");
-
-            if (result.IssuedClientCertificate == null)
+            finally
             {
-                _logger.LogError($"Expected operational certificate was not returned by DPS, so exiting this sample.");
-                return;
+                CleanupCertificates();
+
+                _logger.LogInformation("Finished.");
             }
-
-            // This sample uses openssl to generate the pfx certificate from the issued operational certificate and the previously created ECC P-256 keypair.
-            // This certificate will be used when authneticating with IoT hub.
-            _logger.LogInformation("Creating an X509 certificate from the issued operational certificate...");
-            using X509Certificate2 clientCertificate = GenerateOperationalCertificateFromIssuedCertificate(result.RegistrationId, result.IssuedClientCertificate);
-            IAuthenticationMethod auth = new DeviceAuthenticationWithX509Certificate(result.DeviceId, clientCertificate);
-
-            _logger.LogInformation($"Testing the provisioned device with IoT Hub...");
-            using DeviceClient iotClient = DeviceClient.Create(result.AssignedHub, auth, _parameters.TransportType);
-
-            _logger.LogInformation("Sending a telemetry message...");
-            using var message = new Message(Encoding.UTF8.GetBytes("TestMessage"));
-            await iotClient.SendEventAsync(message);
-            await iotClient.CloseAsync();
-
-            CleanupCertificates();
-
-            _logger.LogInformation("Finished.");
         }
 
         private ProvisioningTransportHandler GetTransportHandler()

--- a/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/ProvisioningDeviceClientSample.cs
+++ b/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/ProvisioningDeviceClientSample.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Samples
                 // DPS will forward your signing request to your linked certificate authority (CA).
                 // The CA will sign and return an operational X509 device identity certificate (aka client certificate) to DPS.
                 // DPS will register the device and operational client certificate thumbprint in IoT hub and return the certificate to the IoT device.
-                // The IoT device can then use the operational certificate to authenticate with IoT Hub.
+                // The IoT device can then use the operational certificate to authenticate with IoT hub.
 
                 var registrationData = new ProvisioningRegistrationAdditionalData
                 {

--- a/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/ProvisioningDeviceClientSample.cs
+++ b/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/ProvisioningDeviceClientSample.cs
@@ -78,7 +78,8 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Samples
                 _logger.LogInformation($"Registration status: {result.Status}.");
                 if (result.Status != ProvisioningRegistrationStatusType.Assigned)
                 {
-                    _logger.LogError($"Registration status did not assign a hub, so exiting this sample.");
+                    _logger.LogError($"Registration status did not assign a hub, so exiting this sample. You will nede to inspect the registration result and take appropriate next steps.");
+                    _logger.LogError($"Error code: {result.ErrorCode}, error message: {result.ErrorMessage}.");
                     return;
                 }
 

--- a/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/ProvisioningDeviceClientSample.cs
+++ b/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/ProvisioningDeviceClientSample.cs
@@ -1,0 +1,177 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Azure.Devices.Client;
+using Microsoft.Azure.Devices.Provisioning.Client.Transport;
+using Microsoft.Azure.Devices.Shared;
+using Microsoft.Extensions.Logging;
+using System.Diagnostics;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+
+namespace Microsoft.Azure.Devices.Provisioning.Client.Samples
+{
+    /// <summary>
+    /// Demonstrates how to register a device with the device provisioning service using a symmetric key, and then
+    /// use the registration information to authenticate to IoT Hub.
+    /// </summary>
+    internal class ProvisioningDeviceClientSample
+    {
+        private readonly Parameters _parameters;
+        private readonly ILogger _logger;
+        private readonly DirectoryInfo s_dpsClientCertificateFolder;
+
+        public ProvisioningDeviceClientSample(Parameters parameters, ILogger logger)
+        {
+            _parameters = parameters;
+            _logger = logger;   
+
+            // Create a folder to hold the DPS client certificates. If a folder by the same name already exists, it will be used.
+            s_dpsClientCertificateFolder = Directory.CreateDirectory("DpsClientCertificates");
+        }
+
+        public async Task RunSampleAsync()
+        {
+            // Generate the certificate signing request for requesting X509 onboarding certificate for authenticating with IoT hub.
+            // This sample uses openssl to generate an ECC P-256 keypair and the corresponding certificate signing request.
+            string certificateSigningRequest = GenerateClientCertKeyPairAndCsr(_parameters.Id);
+
+            _logger.LogInformation($"Initializing the device provisioning client...");
+
+            // For individual enrollments, the first parameter must be the registration Id, where in the enrollment
+            // the device Id is already chosen. However, for group enrollments the device Id can be requested by
+            // the device, as long as the key has been computed using that value.
+            // Also, the secondary key could be included, but was left out for the simplicity of this sample.
+            using var security = new SecurityProviderSymmetricKey(
+                _parameters.Id,
+                _parameters.PrimaryKey,
+                null);
+
+            using var transportHandler = GetTransportHandler();
+
+            // Pass in your onboarding credentials when creating your provisioning device client instance.
+            // This credential will be used to authenticate your request with the device provisioning service (DPS).
+            ProvisioningDeviceClient provClient = ProvisioningDeviceClient.Create(
+                _parameters.GlobalDeviceEndpoint,
+                _parameters.IdScope,
+                security,
+                transportHandler);
+
+            _logger.LogInformation($"Initialized for registration Id {security.GetRegistrationID()}.");
+
+            // Pass in your certificate signing request along with the registration request.
+            // DPS will forward your signing request to your linked certificate authority (CA).
+            // The CA will sign and return an operational X509 device identity certificate (aka client certificate) to DPS.
+            // DPS will register the device and operational client certificate thumbprint in IoT Hub and return the certificate to the IoT device.
+            // The IoT device can then use the operational certificate to authenticate with IoT Hub.
+
+            var registrationData = new ProvisioningRegistrationAdditionalData
+            {
+                OperationalCertificateRequest = certificateSigningRequest,
+            };
+
+            _logger.LogInformation("Registering with the device provisioning service...");
+            DeviceRegistrationResult result = await provClient.RegisterAsync(registrationData);
+
+            _logger.LogInformation($"Registration status: {result.Status}.");
+            if (result.Status != ProvisioningRegistrationStatusType.Assigned)
+            {
+                _logger.LogError($"Registration status did not assign a hub, so exiting this sample.");
+                return;
+            }
+
+            _logger.LogInformation($"Device {result.DeviceId} registered to {result.AssignedHub}.");
+
+            if (result.IssuedClientCertificate == null)
+            {
+                _logger.LogError($"Expected operational certificate was not returned by DPS, so exiting this sample.");
+                return;
+            }
+
+            // This sample uses openssl to generate the pfx certificate from the issued operational certificate and the previously created ECC P-256 keypair.
+            // This certificate will be used when authneticating with IoT hub.
+            _logger.LogInformation("Creating an X509 certificate from the issued operational certificate...");
+            using X509Certificate2 clientCertificate = GenerateOperationalCertificateFromIssuedCertificate(result.RegistrationId, result.IssuedClientCertificate);
+            IAuthenticationMethod auth = new DeviceAuthenticationWithX509Certificate(result.DeviceId, clientCertificate);
+
+            _logger.LogInformation($"Testing the provisioned device with IoT Hub...");
+            using DeviceClient iotClient = DeviceClient.Create(result.AssignedHub, auth, _parameters.TransportType);
+
+            _logger.LogInformation("Sending a telemetry message...");
+            using var message = new Message(Encoding.UTF8.GetBytes("TestMessage"));
+            await iotClient.SendEventAsync(message);
+            await iotClient.CloseAsync();
+
+            CleanupCertificates();
+
+            _logger.LogInformation("Finished.");
+        }
+
+        private ProvisioningTransportHandler GetTransportHandler()
+        {
+            return _parameters.TransportType switch
+            {
+                TransportType.Mqtt => new ProvisioningTransportHandlerMqtt(),
+                TransportType.Mqtt_Tcp_Only => new ProvisioningTransportHandlerMqtt(TransportFallbackType.TcpOnly),
+                TransportType.Mqtt_WebSocket_Only => new ProvisioningTransportHandlerMqtt(TransportFallbackType.WebSocketOnly),
+                TransportType.Amqp => new ProvisioningTransportHandlerAmqp(),
+                TransportType.Amqp_Tcp_Only => new ProvisioningTransportHandlerAmqp(TransportFallbackType.TcpOnly),
+                TransportType.Amqp_WebSocket_Only => new ProvisioningTransportHandlerAmqp(TransportFallbackType.WebSocketOnly),
+                TransportType.Http1 => new ProvisioningTransportHandlerHttp(),
+                _ => throw new NotSupportedException($"Unsupported transport type {_parameters.TransportType}"),
+            };
+        }
+
+        private string GenerateClientCertKeyPairAndCsr(string registrationId)
+        {
+            // Generate keypair
+            _logger.LogInformation($"Generating ECC P-256 {registrationId}.key file using ...");
+            string keygen = $"ecparam -genkey -name prime256v1 -out {s_dpsClientCertificateFolder}\\{registrationId}.key";
+            _logger.LogInformation($"openssl {keygen}");
+            using (var cmdProcess = Process.Start("openssl", keygen))
+            {
+                cmdProcess.WaitForExit();
+            }
+
+            // Generate csr
+            _logger.LogInformation($"Generating {registrationId}.csr file using ...");
+            string csrgen = $"req -new -key {s_dpsClientCertificateFolder}\\{registrationId}.key -out {s_dpsClientCertificateFolder}\\{registrationId}.csr -subj /CN={registrationId}";
+            _logger.LogInformation($"openssl {csrgen}");
+            using (var cmdProcess = Process.Start("openssl", csrgen))
+            {
+                cmdProcess.WaitForExit();
+            }
+
+            return File.ReadAllText($"{s_dpsClientCertificateFolder}\\{registrationId}.csr");
+        }
+
+        private X509Certificate2 GenerateOperationalCertificateFromIssuedCertificate(string registrationId, string issuedCertificate)
+        {
+            // Write the issued certificate to disk
+            File.WriteAllText($"{s_dpsClientCertificateFolder}\\{registrationId}.cer", issuedCertificate);
+
+            _logger.LogInformation($"Generating {registrationId}.pfx file using ...");
+            string pfxgen = $"pkcs12 -export -out {s_dpsClientCertificateFolder}\\{registrationId}.pfx -inkey {s_dpsClientCertificateFolder}\\{registrationId}.key -in {s_dpsClientCertificateFolder}\\{registrationId}.cer -passout pass:";
+            _logger.LogInformation($"openssl {pfxgen}");
+            using (var exeProcess = Process.Start("openssl", pfxgen))
+            {
+                exeProcess.WaitForExit();
+            }
+
+            return new X509Certificate2($"{s_dpsClientCertificateFolder}\\{registrationId}.pfx");
+        }
+
+        private void CleanupCertificates()
+        {
+            // Delete all the client certificates created for the sample
+            try
+            {
+                s_dpsClientCertificateFolder.Delete(true);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"Exception occured while deleting client certificates: {ex.Message}");
+            }
+        }
+    }
+}

--- a/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/ProvisioningDeviceClientSample.cs
+++ b/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/ProvisioningDeviceClientSample.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Samples
 {
     /// <summary>
     /// Demonstrates how to register a device with the device provisioning service using a symmetric key, and then
-    /// use the registration information to authenticate to IoT Hub.
+    /// use the registration information to authenticate to IoT hub.
     /// </summary>
     internal class ProvisioningDeviceClientSample
     {

--- a/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/SymmetricKeyWithOperationalCertificateSample.csproj
+++ b/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/SymmetricKeyWithOperationalCertificateSample.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+	  <PackageReference Include="CommandLineParser" Version="2.8.0" />
+	  <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.41.0-preview-001" />
+	  <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Client" Version="1.20.0-preview-001" />
+
+	  <!-- Note: Applications should not need to import all 3 protocols. This was done to simplify protocol selection within the sample.-->
+	  <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Transport.Mqtt" Version="1.18.0-preview-001" />
+	  <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Transport.Amqp" Version="1.17.0-preview-001" />
+	  <PackageReference Include="Microsoft.Azure.Devices.Provisioning.Transport.Http" Version="1.16.0-preview-001" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\helpers\ColorConsoleLogger\ColorConsoleLogger.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/SymmetricKeyWithOperationalCertificateSample.csproj
+++ b/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/SymmetricKeyWithOperationalCertificateSample.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
+	<LangVersion>8.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/media/crs.puml
+++ b/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/media/crs.puml
@@ -1,0 +1,27 @@
+@startuml dpsCSR
+Device -> Device: Generate **operational** ECC/RSA key-pair
+Device -> Device: Creates Certificate Signing Request using **operational** key-pair
+Device -> DPS: Authenticate using SAS, TPM or Client X509 **onboarding** credentials
+DPS -> Device: ACK
+Device -> DPS: register (registrationId, Body: **operational** CSR)
+DPS -> Device: ACK
+DPS -> CertificateAuthority: **operational** CSR
+DPS <- CertificateAuthority: **operational** X509 Certificate
+Device -> DPS: query [...]
+DPS -> Device: hubFQDN, deviceId, **operational** X509 Certificate
+Device -> HUB: Authenticate using **operational** X509 Certificate
+HUB->HUB: Device **operational** X509 Certificate expired.
+Device <- HUB: MQTT Disconnect
+note left
+  MQTT 3 does not contain 
+  additional disconnect reason.
+end note
+Device -> HUB: Auth using **operational** X509 Certificate
+Device <- HUB: Authentication Failure
+note left
+  This step necessary only 
+  when using MQTT 3.
+end note
+Device -> Device: Restart flow
+
+@enduml

--- a/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/media/crs.puml
+++ b/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/media/crs.puml
@@ -1,5 +1,5 @@
 @startuml dpsCSR
-Device -> Device: Generate **operational** ECC/RSA key-pair
+Device -> Device: Generate **operational** ECC/RSA public-private key-pair
 Device -> Device: Creates Certificate Signing Request using **operational** key-pair
 Device -> DPS: Authenticate using SAS, TPM or Client X509 **onboarding** credentials
 DPS -> Device: ACK

--- a/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/readme.md
+++ b/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/readme.md
@@ -1,9 +1,8 @@
 # Using Azure IoT Device Provisioning Certificate Signing Requests
 
 - Device Provisioning Service (DPS) can be configured to receive Certificate Signing Requests (CSRs) from IoT devices as a part of the DPS registration process. DPS will then forward the CSR on to the Certificate Authority (CA) linked to your DPS instance. 
-- The CA will sign and return an X.509 device identity certificate (aka client certificate) to DPS. We refer to this as an operational certificate. DPS will register the device and operational client certificate thumbprint in IoT Hub and return the certificate to the IoT device. The IoT device can then use the operational certificate to authenticate with IoT Hub. 
-- An onboarding authentication mechanism (either SAS token or X509 Client 
-Certificate) is still required to authenticate the device with DPS.
+- The CA will sign and return an X.509 device identity certificate (aka client certificate) to DPS. We refer to this as an operational certificate. DPS will register the device and operational client certificate thumbprint in IoT hub and return the certificate to the IoT device. The IoT device can then use the operational certificate to authenticate with IoT hub. 
+- An onboarding authentication mechanism (either SAS token or X509 client certificate) is still required to authenticate the device with DPS.
 
 ## Certificate Signing Request Flow
 
@@ -31,7 +30,7 @@ Certificate) is still required to authenticate the device with DPS.
 ## Sample
 
 The `SymmetricKeyWithOperationalCertificateSample` demonstrates how to use the public API to submit a certificate 
-signing request then use the provisioned device certificate when connecting to Azure IoT Hub.
+signing request then use the provisioned device certificate when connecting to Azure IoT hub.
 
 This sample uses symmetric keys for the onboarding authentication with DPS. You can use either SAS token based (symmetric key or TPM) or X509 certificate based authentication for the onboarding authentication with DPS.
 
@@ -39,7 +38,7 @@ This sample uses symmetric keys for the onboarding authentication with DPS. You 
 
     1. Using curl, submit the following command to the DPS Service API to create a CA object in DPS.
 
-        **Note:** On Windows, we recommend using curl from the Linux subsystem for Windows.
+        > **Note:** On Windows, we recommend using curl from the Linux subsystem for Windows.
 
         For **DigiCert**:
         
@@ -91,7 +90,7 @@ This sample uses symmetric keys for the onboarding authentication with DPS. You 
 
 1. Run the sample
 
-    1. The sample uses OpenSSL to generate an ECC P-256 keypair and certificate signing request.
+    1. The sample uses OpenSSL to generate an ECC P-256 public and private key-pair and certificate signing request.
         ```bash
         openssl ecparam -genkey -name prime256v1 -out device1.key
         ```
@@ -99,11 +98,11 @@ This sample uses symmetric keys for the onboarding authentication with DPS. You 
         openssl req -new -key device1.key -out device1.csr -subj '/CN=myregistration-id'
         ```
 
-        **Important**: DPS has [character set
+        > **Important**: DPS has [character set
     restrictions for registration
     ID](https://docs.microsoft.com/en-us/azure/iot-dps/concepts-service#registration-id).
         
-        **Note:** The same CSR can be reused and sent to DPS multiple times. You do not have to regenerate the CSR each time. DPS does not impose any restrictions on the cipher suite and key length that can be used. You are free to use RSA or ECC. However, your CA profile must support the cipher suite and key length.
+        > **Note:** The same CSR can be reused and sent to DPS multiple times. You do not have to regenerate the CSR each time. DPS does not impose any restrictions on the cipher suite and key length that can be used. You are free to use RSA or ECC. However, your CA profile must support the cipher suite and key length.
 
     1. The certificate signing request generated is sent to DPS through the following API
         ```c#
@@ -112,7 +111,7 @@ This sample uses symmetric keys for the onboarding authentication with DPS. You 
 
     1. DPS forwards the certificate signing request to your linked Certificate Authority which signs the request and returns the signed operational certificate. 
 
-    1. The IoT Hub Device SDK needs both the signed certificate as well as the private key information. It expects to load a single PFX-formatted bundle containing all necessarily information. This sample uses OpenSSL to combine the key and certificate to create the PFX file:
+    1. The IoT hub Device SDK needs both the signed certificate as well as the private key information. It expects to load a single PFX-formatted bundle containing all necessarily information. This sample uses OpenSSL to combine the key and certificate to create the PFX file:
         ```bash
         openssl pkcs12 -export -out device1.pfx -inkey device1.key -in device1.cer
         ```

--- a/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/readme.md
+++ b/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/readme.md
@@ -1,0 +1,120 @@
+# Using Azure IoT Device Provisioning Certificate Signing Requests
+
+- Device Provisioning Service (DPS) can be configured to receive Certificate Signing Requests (CSRs) from IoT devices as a part of the DPS registration process. DPS will then forward the CSR on to the Certificate Authority (CA) linked to your DPS instance. 
+- The CA will sign and return an X.509 device identity certificate (aka client certificate) to DPS. We refer to this as an operational certificate. DPS will register the device and operational client certificate thumbprint in IoT Hub and return the certificate to the IoT device. The IoT device can then use the operational certificate to authenticate with IoT Hub. 
+- An onboarding authentication mechanism (either SAS token or X509 Client 
+Certificate) is still required to authenticate the device with DPS.
+
+## Certificate Signing Request Flow
+
+![dpsCSR](https://www.plantuml.com/plantuml/png/bPFVJy8m4CVVzrVSeoumJOmF4aCOGzGO331CJ8mFPJsWSRQpxKJ-Uwyh69nBmBV-kC_tldVNzenbsfRlEV329Eaq6E2do13QNV2h3joYHCqiGXYgmgs4aYmFGxX9ahDf6iCRRje54xg1JJGIQI11RSL2P4uc5Kifv1Ac-56YiL0QjwkBDucEqmx4fLsXj5xAescSjc0s7e7IaEI2Rk7vylpAISgvOffJ42bc6haZMMu2ajgt6ISFzJmQby9Or73YLzxQFMz1N_5DvuzVwjrfewm_sck0gq1fOPj5Ak2wVIHGrRaNMg-2Egmty195qMlTtAgS3oU3nnRmwi1LzW_rkwT-uomEIX3OxbRqLkmG0VXL21fTjCjEpQduqMGsWu4mcP8ICnj8HS4vBcm0_ku2kAAtH-T0CPO92NJ5E1S-6V0VcCRDZ99HW98xeB7KOqki-Tph4Y4mP28lDVwoEri90_JQ2Y0pQ0oZeIcPRvpVDS7RpBwgHfExgKwn-j2moDKw27eKIN_x6m00 "dpsCSR")
+
+## Public API
+
+```diff
+{
+     namespace Microsoft.Azure.Devices.Provisioning.Client {
+         public class ProvisioningDeviceClient {
+             public Task<DeviceRegistrationResult> RegisterAsync(ProvisioningRegistrationAdditionalData data, CancellationToken cancellationToken = default(CancellationToken));
+             public Task<DeviceRegistrationResult> RegisterAsync(ProvisioningRegistrationAdditionalData data, TimeSpan timeout);
+         }
+         public class ProvisioningRegistrationAdditionalData {
++          public string OperationalCertificateRequest { get; set; }
+         }
+         public class DeviceRegistrationResult {
++           public string IssuedClientCertificate { get; set; }
+         }
+     }
+ }
+```
+
+## Sample
+
+The `SymmetricKeyWithOperationalCertificateSample` demonstrates how to use the public API to submit a certificate 
+signing request then use the provisioned device certificate when connecting to Azure IoT Hub.
+
+This sample uses symmetric keys for the onboarding authentication with DPS. You can use either SAS token based (symmetric key or TPM) or X509 certificate based authentication for the onboarding authentication with DPS.
+
+1. Prerequisites
+
+    1. Using curl, submit the following command to the DPS Service API to create a CA object in DPS.
+
+        **Note:** On Windows, we recommend using curl from the Linux subsystem for Windows.
+
+        For **DigiCert**:
+        
+        ```bash
+        curl -k -L -i -X PUT https://<dps_service_endpoint>/certificateAuthorities/<ca_name>?api-version=2021-11-01-preview -H "Authorization: <service_api_sas_token>" -H "Content-Type: application/json" -H "Content-Encoding: utf-8" -d"{'certificateAuthorityType':'DigiCertCertificateAuthority','apiKey':'<api_key>','profileName':'<profile_id>'}"
+        ```
+
+        Where:
+        - **<dps_service_endpoint>** - Your DPS Service Endpoint from the DPS Overview blade in Azure.
+        - **<ca_name>** - The friendly name you wish to assign to your CA. A lower-case string (up to 128 characters long) of alphanumeric characters plus certain special characters : ._ -. No special characters allowed at start or end. 
+        - **<service_api_sas_token>** - The DPS Service API shared access token.
+        - **<api_key>** - Your DigiCert API key.
+        - **<profile_id>** - Your DigiCert **Client Cert Profile ID**.
+
+    1. Create a symmetric key enrollment in DPS and link it to your Certificate Authority.
+        Linking your enrollment to the Certificate Authority is currently unavailable through the portal, so you will need to run the following curl commands.
+
+        1. Query the Service API for your individual enrollment:
+
+            ```bash
+            curl -X GET -H "Content-Type: application/json" -H "Content-Encoding:  utf-8" -H "Authorization: <service_api_sas_token>" https://<dps_service_endpoint>/enrollments/<registration_id>?api-version=2021-11-01-preview > enrollment.json
+            ```
+
+            Where:
+            - **<dps_service_endpoint>** - Your DPS Service Endpoint from the DPS Overview blade in Azure.
+            - **<service_api_sas_token>** - The DPS Service API shared access token.
+            - **<registration_id>** - The RegistrationID of the individual entrollment that you'd like to modify.
+
+        1.  Update the individual enrollment as follows, using the above JSON. Edit the `enrollment.json` file to add the following information:
+            ```json
+            "clientCertificateIssuancePolicy": {
+                "certificateAuthorityName": "ca1"
+            }
+            ```
+            
+            Replace ca1 with **<ca_name>**.
+
+        1. Update the enrollment information:
+
+            ```bash
+            curl -k -L -i -X PUT -H "Content-Type: application/json" -H "Content-Encoding:  utf-8" -H "Authorization: <service_api_sas_token>" https://<dps_service_endpoint>/enrollments/<registration_id>?api-version=2021-11-01-preview -H "If-Match: <etag>" -d @enrollment.json
+            ```
+
+            Where:
+            - **<dps_service_endpoint>** - Your DPS Service Endpoint from the DPS Overview blade in Azure.
+            - **<registration_id>** – The RegistrationID of the individual entrollment that you'd like to modify.
+            - **<service_api_sas_token>** - The DPS Service API shared access token.
+            - **<etag>** - The etag found in enrollment.json 
+
+1. Run the sample
+
+    1. The sample uses OpenSSL to generate an ECC P-256 keypair and certificate signing request.
+        ```bash
+        openssl ecparam -genkey -name prime256v1 -out device1.key
+        ```
+        ```bash
+        openssl req -new -key device1.key -out device1.csr -subj '/CN=myregistration-id'
+        ```
+
+        **Important**: DPS has [character set
+    restrictions for registration
+    ID](https://docs.microsoft.com/en-us/azure/iot-dps/concepts-service#registration-id).
+        
+        **Note:** The same CSR can be reused and sent to DPS multiple times. You do not have to regenerate the CSR each time. DPS does not impose any restrictions on the cipher suite and key length that can be used. You are free to use RSA or ECC. However, your CA profile must support the cipher suite and key length.
+
+    1. The certificate signing request generated is sent to DPS through the following API
+        ```c#
+        public Task<DeviceRegistrationResult> RegisterAsync(ProvisioningRegistrationAdditionalData data, CancellationToken cancellationToken = default);
+        ```
+
+    1. DPS forwards the certificate signing request to your linked Certificate Authority which signs the request and returns the signed operational certificate. 
+
+    1. The IoT Hub Device SDK needs both the signed certificate as well as the private key information. It expects to load a single PFX-formatted bundle containing all necessarily information. This sample uses OpenSSL to combine the key and certificate to create the PFX file:
+        ```bash
+        openssl pkcs12 -export -out device1.pfx -inkey device1.key -in device1.cer
+        ```
+
+    1. The authenticated client is used to send a telemetry message to the assigned IoT hub and then close the connection.


### PR DESCRIPTION
Updated the [SymmetricKeySample](https://github.com/Azure-Samples/azure-iot-samples-csharp/tree/preview/provisioning/Samples/device/SymmetricKeySample) to demonstrate DPS client certificate issuance.

Readme: https://github.com/Azure-Samples/azure-iot-samples-csharp/tree/abmisr/dpsClientCerts/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample