### PR TITLE
refactor(prov-device): Rename variables for accepting client certificate signing requests

### DIFF
--- a/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/Parameters.cs
+++ b/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/Parameters.cs
@@ -36,21 +36,21 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Samples
             'e',
             "EnrollmentType",
             Default = EnrollmentType.Individual,
-            HelpText = "The type of enrollment: Individual or Group")]
+            HelpText = "The type of enrollment: Individual or Group. This defaults to EnrollmentType.Individual.")]
         public EnrollmentType EnrollmentType { get; set; }
 
         [Option(
             'g',
             "GlobalDeviceEndpoint",
             Default = "global.azure-devices-provisioning.net",
-            HelpText = "The global endpoint for devices to connect to.")]
+            HelpText = "The global endpoint for devices to connect to. This defaults to global.azure-devices-provisioning.net.")]
         public string GlobalDeviceEndpoint { get; set; }
 
         [Option(
             't',
             "TransportType",
             Default = TransportType.Mqtt,
-            HelpText = "The transport to use to communicate with the device provisioning instance. Possible values include Mqtt, Mqtt_WebSocket_Only, Mqtt_Tcp_Only, Amqp, Amqp_WebSocket_Only, Amqp_Tcp_only, and Http1.")]
+            HelpText = "The transport to use to communicate with the device provisioning instance. Possible values include Mqtt, Mqtt_WebSocket_Only, Mqtt_Tcp_Only, Amqp, Amqp_WebSocket_Only, Amqp_Tcp_only, and Http1. This defaults to Mqtt.")]
         public TransportType TransportType { get; set; }
     }
 }

--- a/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/Program.cs
+++ b/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/Program.cs
@@ -5,8 +5,6 @@ using CommandLine;
 using Microsoft.Azure.Devices.Logging;
 using Microsoft.Azure.Devices.Provisioning.Client.Samples;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Threading.Tasks;
 
 namespace SymmetricKeySample
 {

--- a/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/ProvisioningDeviceClientSample.cs
+++ b/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/ProvisioningDeviceClientSample.cs
@@ -62,12 +62,12 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Samples
                 // Pass in your certificate signing request along with the registration request.
                 // DPS will forward your signing request to your linked certificate authority (CA).
                 // The CA will sign and return an operational X509 device identity certificate (aka client certificate) to DPS.
-                // DPS will register the device and operational client certificate thumbprint in IoT hub and return the certificate to the IoT device.
-                // The IoT device can then use the operational certificate to authenticate with IoT hub.
+                // DPS will register the device and operational client certificate thumbprint in IoT hub and return the certificate with the public key to the IoT device.
+                // The IoT device can then use this returned operational certificate along with the private key information to authenticate with IoT Hub.
 
                 var registrationData = new ProvisioningRegistrationAdditionalData
                 {
-                    OperationalCertificateRequest = certificateSigningRequest,
+                    ClientCertificateSigningRequest = certificateSigningRequest,
                 };
 
                 _logger.LogInformation("Registering with the device provisioning service...");

--- a/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/ProvisioningDeviceClientSample.cs
+++ b/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/ProvisioningDeviceClientSample.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Samples
                 // DPS will forward your signing request to your linked certificate authority (CA).
                 // The CA will sign and return an operational X509 device identity certificate (aka client certificate) to DPS.
                 // DPS will register the device and operational client certificate thumbprint in IoT hub and return the certificate with the public key to the IoT device.
-                // The IoT device can then use this returned operational certificate along with the private key information to authenticate with IoT Hub.
+                // The IoT device can then use this returned client certificate along with the private key information to authenticate with IoT Hub.
 
                 var registrationData = new ProvisioningRegistrationAdditionalData
                 {

--- a/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/ProvisioningDeviceClientSample.cs
+++ b/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/ProvisioningDeviceClientSample.cs
@@ -62,8 +62,8 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Samples
                 // Pass in your certificate signing request along with the registration request.
                 // DPS will forward your signing request to your linked certificate authority (CA).
                 // The CA will sign and return an operational X509 device identity certificate (aka client certificate) to DPS.
-                // DPS will register the device and operational client certificate thumbprint in IoT hub and return the certificate with the public key to the IoT device.
-                // The IoT device can then use this returned client certificate along with the private key information to authenticate with IoT Hub.
+                // DPS will register the device and client certificate thumbprint in IoT hub and return the certificate with the public key to the IoT device.
+                // The IoT device can then use this returned client certificate along with the private key information to authenticate with IoT hub.
 
                 var registrationData = new ProvisioningRegistrationAdditionalData
                 {
@@ -85,13 +85,13 @@ namespace Microsoft.Azure.Devices.Provisioning.Client.Samples
 
                 if (result.IssuedClientCertificate == null)
                 {
-                    _logger.LogError($"Expected operational certificate was not returned by DPS, so exiting this sample.");
+                    _logger.LogError($"Expected client certificate was not returned by DPS, so exiting this sample.");
                     return;
                 }
 
-                // This sample uses openssl to generate the pfx certificate from the issued operational certificate and the previously created ECC P-256 public-private key pair.
-                // This certificate will be used when authneticating with IoT hub.
-                _logger.LogInformation("Creating an X509 certificate from the issued operational certificate...");
+                // This sample uses openssl to generate the pfx certificate from the issued client certificate and the previously created ECC P-256 public-private key pair.
+                // This certificate will be used when authenticating with IoT hub.
+                _logger.LogInformation("Creating an X509 certificate from the issued client certificate...");
                 using X509Certificate2 clientCertificate = GenerateOperationalCertificateFromIssuedCertificate(result.RegistrationId, result.IssuedClientCertificate);
                 IAuthenticationMethod auth = new DeviceAuthenticationWithX509Certificate(result.DeviceId, clientCertificate);
 

--- a/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/SymmetricKeyWithOperationalCertificateSample.csproj
+++ b/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/SymmetricKeyWithOperationalCertificateSample.csproj
@@ -3,9 +3,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
 	  <PackageReference Include="CommandLineParser" Version="2.8.0" />

--- a/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/readme.md
+++ b/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/readme.md
@@ -1,7 +1,7 @@
 # Using Azure IoT Device Provisioning Certificate Signing Requests
 
 - Device Provisioning Service (DPS) can be configured to receive Certificate Signing Requests (CSRs) from IoT devices as a part of the DPS registration process. DPS will then forward the CSR on to the Certificate Authority (CA) linked to your DPS instance. 
-- The CA will sign and return an X.509 device identity certificate (aka client certificate) to DPS. We refer to this as an operational certificate. DPS will register the device and operational client certificate thumbprint in IoT hub and return the certificate to the IoT device. The IoT device can then use the returned operational certificate along with the private key information to authenticate with IoT Hub.
+- The CA will sign and return an X.509 device identity certificate (aka client certificate) to DPS. We refer to this as an operational certificate. DPS will register the device and operational client certificate thumbprint in IoT hub and return the certificate to the IoT device. The IoT device can then use the returned operational certificate along with the private key information to authenticate with IoT hub.
 - An onboarding authentication mechanism (either SAS token or X509 client certificate) is still required to authenticate the device with DPS.
 
 ## Certificate Signing Request Flow

--- a/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/readme.md
+++ b/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/readme.md
@@ -1,7 +1,7 @@
 # Using Azure IoT Device Provisioning Certificate Signing Requests
 
 - Device Provisioning Service (DPS) can be configured to receive Certificate Signing Requests (CSRs) from IoT devices as a part of the DPS registration process. DPS will then forward the CSR on to the Certificate Authority (CA) linked to your DPS instance. 
-- The CA will sign and return an X.509 device identity certificate (aka client certificate) to DPS. We refer to this as an operational certificate. DPS will register the device and operational client certificate thumbprint in IoT hub and return the certificate to the IoT device. The IoT device can then use the returned operational certificate along with the private key information to authenticate with IoT hub.
+- The CA will sign and return an X.509 device identity certificate (aka client certificate) to DPS. We will refer to this here as an operational certificate. DPS will register the device and operational client certificate thumbprint in IoT hub and return the certificate with the public key to the IoT device. The IoT device can then use the returned client certificate along with the private key information to authenticate with IoT hub.
 - An onboarding authentication mechanism (either SAS token or X509 client certificate) is still required to authenticate the device with DPS.
 
 ## Certificate Signing Request Flow
@@ -105,11 +105,11 @@ This sample uses symmetric keys for the onboarding authentication with DPS. You 
         public class ProvisioningRegistrationAdditionalData
         {
             public string JsonData { get; set; }
-            public string OperationalCertificateRequest { get; set; }
+            public string ClientCertificateSigningRequest { get; set; }
         }
         ```
 
-    1. DPS forwards the certificate signing request to your linked Certificate Authority which signs the request and returns the signed operational certificate. 
+    1. DPS forwards the certificate signing request to your linked Certificate Authority which signs the request and returns the signed operational client certificate. 
 
     1. The IoT hub Device SDK needs both the signed certificate as well as the private key information. It expects to load a single PFX-formatted bundle containing all necessarily information. This sample uses OpenSSL to combine the key and certificate to create the PFX file:
         ```bash

--- a/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/readme.md
+++ b/provisioning/Samples/device/SymmetricKeyWithOperationalCertificateSample/readme.md
@@ -1,7 +1,7 @@
 # Using Azure IoT Device Provisioning Certificate Signing Requests
 
 - Device Provisioning Service (DPS) can be configured to receive Certificate Signing Requests (CSRs) from IoT devices as a part of the DPS registration process. DPS will then forward the CSR on to the Certificate Authority (CA) linked to your DPS instance. 
-- The CA will sign and return an X.509 device identity certificate (aka client certificate) to DPS. We refer to this as an operational certificate. DPS will register the device and operational client certificate thumbprint in IoT hub and return the certificate to the IoT device. The IoT device can then use the operational certificate to authenticate with IoT hub. 
+- The CA will sign and return an X.509 device identity certificate (aka client certificate) to DPS. We refer to this as an operational certificate. DPS will register the device and operational client certificate thumbprint in IoT hub and return the certificate to the IoT device. The IoT device can then use the returned operational certificate along with the private key information to authenticate with IoT Hub.
 - An onboarding authentication mechanism (either SAS token or X509 client certificate) is still required to authenticate the device with DPS.
 
 ## Certificate Signing Request Flow
@@ -20,7 +20,7 @@ From [Azure IoT C-SDK](https://github.com/Azure/azure-iot-sdk-c/blob/59d9ae9131f
              public Task<DeviceRegistrationResult> RegisterAsync(ProvisioningRegistrationAdditionalData data, TimeSpan timeout);
          }
          public class ProvisioningRegistrationAdditionalData {
-+          public string OperationalCertificateRequest { get; set; }
++          public string ClientCertificateSigningRequest { get; set; }
          }
          public class DeviceRegistrationResult {
 +           public string IssuedClientCertificate { get; set; }
@@ -102,7 +102,8 @@ This sample uses symmetric keys for the onboarding authentication with DPS. You 
 
         Where:
         ```csharp
-        public class ProvisioningRegistrationAdditionalData {
+        public class ProvisioningRegistrationAdditionalData
+        {
             public string JsonData { get; set; }
             public string OperationalCertificateRequest { get; set; }
         }


### PR DESCRIPTION
Renamed `OperationalCertificateRequest` to `ClientCertificateSigningRequest`.
Also updated some doc comments to highlight that the signed certificate only contains the public key information.