### PR TITLE
removed "en-us" from Azure tutorial link

### DIFF
--- a/iot-hub/Tutorials/Routing/SimulatedDevice/Program.cs
+++ b/iot-hub/Tutorials/Routing/SimulatedDevice/Program.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 //This is the code that sends messages to the IoT Hub for testing the routing as defined
-//  in this article: https://docs.microsoft.com/en-us/azure/iot-hub/tutorial-routing
+//  in this article: https://docs.microsoft.com/azure/iot-hub/tutorial-routing
 //The scripts for creating the resources are included in the resources folder in this
 //  Visual Studio solution. 
 //


### PR DESCRIPTION
<img width="490" alt="image" src="https://user-images.githubusercontent.com/110431552/183129082-07a8af94-a24a-4f65-9c00-55fc90283578.png">

changed the link in the attachment to be location neutral