### PR TITLE
Improved nightly clean up task with clean only build option

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -13,6 +13,7 @@ Parameters:
     -clean: Runs dotnet clean. Use `git clean -xdf` if this is not sufficient.
     -build: Builds the project.
     -run: Runs the sample. The required environmental variables need to be set beforehand.
+    -clear: Clear device and enrollment.
     -configuration {Debug|Release}
     -verbosity: Sets the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
 
@@ -37,6 +38,7 @@ Param(
     [switch] $clean,
     [switch] $build,
     [switch] $run,
+    [switch] $clear,
     [string] $configuration = "Debug",
     [string] $verbosity = "q"
 )
@@ -101,6 +103,14 @@ try {
         BuildProject provisioning\Samples\service "Provisioning Service Samples"
     }
 
+    if ($clear)
+    {
+        # Clear device and enrollment
+        RunApp provisioning\Samples\service\CleanupEnrollmentsSample "Provisioning\Service\CleanupEnrollmentsSample"
+        RunApp iot-hub\Samples\service\CleanupDevicesSample "IoTHub\Service\CleanupDevicesSample" "-c ""$env:IOTHUB_CONNECTION_STRING"" -a ""$env:STORAGE_ACCOUNT_CONNECTION_STRING"" --PathToDevicePrefixForDeletion ""$env:PATH_TO_DEVICE_PREFIX_FOR_DELETION_FILE"""
+        RunApp iot-hub\Samples\service\CleanupDevicesSample "IoTHub\Service\CleanupDevicesSample" "-c ""$env:FAR_AWAY_IOTHUB_CONNECTION_STRING"" -a ""$env:STORAGE_ACCOUNT_CONNECTION_STRING"" --PathToDevicePrefixForDeletion ""$env:PATH_TO_DEVICE_PREFIX_FOR_DELETION_FILE"""
+    }
+
     if ($run)
     {
         $sampleRunningTimeInSeconds = 60
@@ -108,6 +118,7 @@ try {
         # Run cleanup first so the samples don't get overloaded with old devices
         RunApp provisioning\Samples\service\CleanupEnrollmentsSample "Provisioning\Service\CleanupEnrollmentsSample"
         RunApp iot-hub\Samples\service\CleanupDevicesSample "IoTHub\Service\CleanupDevicesSample" "-c ""$env:IOTHUB_CONNECTION_STRING"" -a ""$env:STORAGE_ACCOUNT_CONNECTION_STRING"" --PathToDevicePrefixForDeletion ""$env:PATH_TO_DEVICE_PREFIX_FOR_DELETION_FILE"""
+        RunApp iot-hub\Samples\service\CleanupDevicesSample "IoTHub\Service\CleanupDevicesSample" "-c ""$env:FAR_AWAY_IOTHUB_CONNECTION_STRING"" -a ""$env:STORAGE_ACCOUNT_CONNECTION_STRING"" --PathToDevicePrefixForDeletion ""$env:PATH_TO_DEVICE_PREFIX_FOR_DELETION_FILE"""
 
         # Run the iot-hub\device samples
         RunApp iot-hub\Samples\device\DeviceReconnectionSample "IoTHub\Device\DeviceReconnectionSample" "-p ""$env:IOTHUB_DEVICE_CONN_STRING"" -r $sampleRunningTimeInSeconds"

--- a/vsts/vsts.yaml
+++ b/vsts/vsts.yaml
@@ -37,7 +37,7 @@ jobs:
           version: 2.1.x
           performMultiLevelLookup: true
           installationPath: $(Agent.ToolsDirectory)/dotnet
-      - powershell: ./build.ps1 -clean -configuration Release -build -run
+      - powershell: ./build.ps1 -clean -configuration Release -build -clear
         displayName: build and run
         env:
           # Environment variables for IoT hub device samples
@@ -106,7 +106,7 @@ jobs:
           version: 2.1.x
           performMultiLevelLookup: true
           installationPath: $(Agent.ToolsDirectory)/dotnet
-      - powershell: ./build.ps1 -clean -configuration Release -run
+      - powershell: ./build.ps1 -clean -configuration Release -clear
         displayName: build and run
         env:
           # Environment variables for IoT hub device samples


### PR DESCRIPTION
Add clear switch to build script for clean up only run option
Run 3 clean up processes, skip all samples runs
Shorten execution time from 40+ minutes to about 5 minutes
