### PR TITLE
Don't crash sample when params aren't valid

### DIFF
--- a/iot-hub/Samples/service/DigitalTwinClientSamples/TemperatureController/Program.cs
+++ b/iot-hub/Samples/service/DigitalTwinClientSamples/TemperatureController/Program.cs
@@ -32,9 +32,8 @@ namespace Microsoft.Azure.Devices.Samples
 
             if (!parameters.Validate())
             {
-                throw new ArgumentException("Required parameters are not set. Please recheck required variables by using \"--help\"");
+                throw new ArgumentException("Required parameters are not set. Please recheck required variables by using '--help'.");
             }
-
 
             ILogger logger = InitializeConsoleDebugLogger();
             logger.LogDebug("Set up the digital twin client.");

--- a/iot-hub/Samples/service/ImportExportDevicesSample/Parameters.cs
+++ b/iot-hub/Samples/service/ImportExportDevicesSample/Parameters.cs
@@ -6,51 +6,59 @@ namespace Microsoft.Azure.Devices.Samples
     /// <summary>
     /// Configurable parameters for the sample.
     /// </summary>
+    /// <remarks>
+    /// To get these connection strings, log into https://azure.portal.com, go to Resources, open the IoT hub, open Shared Access Policies, open iothubowner, and copy a connection string.
+    /// </remarks>
     internal class Parameters
     {
         [Option(
             'i',
             "SourceIoTHubConnectionString",
-            Required = true,
-            HelpText = "The service connection string with permissions to manage devices for the source IoT hub to copy devices. Log into https://azure.portal.com, go to Resources, open the IoT hub, open Shared Access Policies, open iothubowner, and copy a connection string.")]
+            Required = false,
+            HelpText = "The service connection string with permissions to manage devices for the source IoT hub to copy devices. "
+                + "Defaults to environment variable 'SOURCE_IOTHUB_CONN_STRING_CSHARP'.")]
         public string SourceIotHubConnectionString { get; set; } = Environment.GetEnvironmentVariable("SOURCE_IOTHUB_CONN_STRING_CSHARP");
 
         [Option(
             'd',
             "DestIoTHubConnectionString",
-            Required = true,
-            HelpText = "The service connection string with permissions to manage devices for the destination IoT hub to migrate devices. Log into https://azure.portal.com, go to Resources, open the IoT hub, open Shared Access Policies, open iothubowner, and copy a connection string.")]
+            Required = false,
+            HelpText = "The service connection string with permissions to manage devices for the destination IoT hub to migrate devices. "
+                + "Defaults to environment variable 'DEST_IOTHUB_CONN_STRING_CSHARP'.")]
         public string DestIotHubConnectionString { get; set; } = Environment.GetEnvironmentVariable("DEST_IOTHUB_CONN_STRING_CSHARP");
 
         [Option(
             's',
             "StorageConnectionString",
-            Required = true,
-            HelpText = "The storage account connection string to use with the IoT hub for migrating device data. Log into https://azure.portal.com, go to Resources, open the storage account, open Access Keys, and copy a connection string.")]
+            Required = false,
+            HelpText = "The storage account connection string to use with the IoT hub for migrating device data "
+                + "Defaults to environment variable 'STORAGE_CONN_STRING_CSHARP'.")]
         public string StorageConnectionString { get; set; } = Environment.GetEnvironmentVariable("STORAGE_CONN_STRING_CSHARP");
 
         [Option(
             "AddDevices",
             Default = 0,
-            HelpText = "Generates the specified number of new devices (and configurations, if specified) and add to the source IoT hub, for migration to the destination IoT hub.")]
+            HelpText = "Generates the specified number of new devices (and configurations, if specified) and add to the source IoT hub, for migration to the destination IoT hub. "
+                + "Defaults to environment variable 'NUM_TO_ADD'.")]
         public int AddDevices { get; set; }
 
         [Option(
             "CopyDevices",
             Default = true,
-            HelpText = "Copies devices (and configurations, if specified) from the source to the destionation IoT hub.")]
+            HelpText = "Copies devices (and configurations, if specified) from the source to the destionation IoT hub. Defaults to environment variable 'COPY_DEVICES'.")]
         public bool CopyDevices { get; set; }
 
         [Option(
             "DeleteSourceDevices",
             Default = false,
-            HelpText = "Deletes generated devices (and configurations, if specified) in the source IoT hub, after migration and this sample is finished.")]
+            HelpText = "Deletes generated devices (and configurations, if specified) in the source IoT hub, after migration and this sample is finished. "
+                + "Defaults to environment variable 'DELETE_SOURCE_DEVICES'.")]
         public bool DeleteSourceDevices { get; set; }
 
         [Option(
             "DeleteDestDevices",
             Default = false,
-            HelpText = "Delete the devices (and configurations, if specified) that were migrated in the destionation IoT hub, after migration and this sample is finished.")]
+            HelpText = "Delete the devices (and configurations, if specified) that were migrated in the destionation IoT hub, after migration and this sample is finished. Defaults to environment variable 'DELETE_DEST_DEVICES'.")]
         public bool DeleteDestDevices { get; set; }
 
         [Option(
@@ -103,6 +111,13 @@ namespace Microsoft.Azure.Devices.Samples
             {
                 DeleteSourceDevices = deleteToDevices;
             }
+        }
+
+        public bool Validate()
+        {
+            return !string.IsNullOrWhiteSpace(SourceIotHubConnectionString)
+                && !string.IsNullOrWhiteSpace(DestIotHubConnectionString)
+                && !string.IsNullOrWhiteSpace(StorageConnectionString);
         }
     }
 }

--- a/iot-hub/Samples/service/ImportExportDevicesSample/Program.cs
+++ b/iot-hub/Samples/service/ImportExportDevicesSample/Program.cs
@@ -57,6 +57,12 @@ namespace Microsoft.Azure.Devices.Samples
                         Environment.Exit(1);
                     });
 
+            if (!parameters.Validate())
+            {
+                Console.WriteLine(CommandLine.Text.HelpText.AutoBuild(result, null, null));
+                Environment.Exit(1);
+            }
+
             try
             {
                 // Instantiate the class and run the sample.

--- a/iot-hub/Samples/service/PnpServiceSamples/Thermostat/Parameters.cs
+++ b/iot-hub/Samples/service/PnpServiceSamples/Thermostat/Parameters.cs
@@ -15,15 +15,15 @@ namespace Microsoft.Azure.Devices.Samples
         [Option(
             'c',
             "HubConnectionString",
-            HelpText = "The IoT Hub connection string. This is available under the \"Shared access policies\" in the Azure portal." +
-            "\nDefaults to environment variable \"IOTHUB_CONNECTION_STRING\".")]
+            HelpText = "The IoT Hub connection string. This is available under the 'Shared access policies' in the Azure portal." +
+            "\nDefaults to environment variable 'IOTHUB_CONNECTION_STRING'.")]
         public string HubConnectionString { get; set; } = Environment.GetEnvironmentVariable("IOTHUB_CONNECTION_STRING");
 
         [Option(
             'd',
             "DeviceId",
             HelpText = "The Id of the plug and play compatible device to be used in the sample." +
-            "\nDefaults to environment variable \"IOTHUB_DEVICE_ID\"")]
+            "\nDefaults to environment variable 'IOTHUB_DEVICE_ID'")]
         public string DeviceId { get; set; } = Environment.GetEnvironmentVariable("IOTHUB_DEVICE_ID");
 
         public bool Validate()
@@ -31,15 +31,15 @@ namespace Microsoft.Azure.Devices.Samples
             if (string.IsNullOrWhiteSpace(HubConnectionString))
             {
                 throw new ArgumentNullException(nameof(HubConnectionString), "An IoT Hub connection string needs to be specified, " +
-                    "please set the environment variable \"IOTHUB_CONNECTION_STRING\" " +
-                    "or pass in \"-c | --HubConnectionString\" through command line.");
+                    "please set the environment variable 'IOTHUB_CONNECTION_STRING' " +
+                    "or pass in '-c | --HubConnectionString' through command line.");
             }
 
             if (string.IsNullOrWhiteSpace(DeviceId))
             {
                 throw new ArgumentNullException(nameof(DeviceId), "The Id of the plug and play device needs to be specified, " +
-                    "please set the environment variable \"IOTHUB_DEVICE_ID\" " +
-                    "or pass in \"-d | --DeviceId\" through command line.");
+                    "please set the environment variable 'IOTHUB_DEVICE_ID' " +
+                    "or pass in '-d | --DeviceId' through command line.");
             }
 
             return true;


### PR DESCRIPTION
1. Samples that only take parameters, don't need to do this. The initial parsing of parameters will gracefully exit the sample and print the help text.
2. Samples that support legacy environment variables need to not have their parameters marked as required, but need after-the-fact validation. The Program.cs file can call validate after, call the method that prints the help text, and exit gracefully with a non-zero error code.