### PR TITLE
Bumped netcoreapp to 6.0

### DIFF
--- a/iot-hub/Tutorials/Routing/SimulatedDevice/SimulatedDevice.csproj
+++ b/iot-hub/Tutorials/Routing/SimulatedDevice/SimulatedDevice.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp6.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
## Purpose
[Routing Tutorial](https://docs.microsoft.com/en-us/azure/iot-hub/tutorial-routing?tabs=portal) does not compile as the target framework is netcoreapp2.1 which has been [deprecated](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core) for quite some time

```
roedy@roedy:~/workspace/azure/iot/azure-iot-samples-csharp/iot-hub/Tutorials/Routing/SimulatedDevice$ dotnet run
/usr/share/dotnet/sdk/6.0.400/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.EolTargetFrameworks.targets(28,5): warning NETSDK1138: The target framework 'netcoreapp2.1' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/dotnet-core-support for more information about the support policy. [/home/roedy/workspace/azure/iot/azure-iot-samples-csharp/iot-hub/Tutorials/Routing/SimulatedDevice/SimulatedDevice.csproj]
/usr/share/dotnet/sdk/6.0.400/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.EolTargetFrameworks.targets(28,5): warning NETSDK1138: The target framework 'netcoreapp2.1' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/dotnet-core-support for more information about the support policy. [/home/roedy/workspace/azure/iot/azure-iot-samples-csharp/iot-hub/Tutorials/Routing/SimulatedDevice/SimulatedDevice.csproj]
/usr/share/dotnet/sdk/6.0.400/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.EolTargetFrameworks.targets(28,5): warning NETSDK1138: The target framework 'netcoreapp2.1' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/dotnet-core-support for more information about the support policy. [/home/roedy/workspace/azure/iot/azure-iot-samples-csharp/iot-hub/Tutorials/Routing/SimulatedDevice/SimulatedDevice.csproj]
You must install or update .NET to run this application.

App: /home/roedy/workspace/azure/iot/azure-iot-samples-csharp/iot-hub/Tutorials/Routing/SimulatedDevice/bin/Debug/netcoreapp2.1/SimulatedDevice.dll
Architecture: x64
Framework: 'Microsoft.NETCore.App', version '2.1.0' (x64)
.NET location: /usr/share/dotnet/

The following frameworks were found:
  6.0.8 at [/usr/share/dotnet/shared/Microsoft.NETCore.App]

Learn about framework resolution:
https://aka.ms/dotnet/app-launch-failed

To install missing framework, download:
https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=2.1.0&arch=x64&rid=debian.11-x64
```



## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe:
Version bump so that online tutorial works
```

## How to Test
*  Get the code
* [Install .NET 6](https://docs.microsoft.com/en-us/dotnet/core/install/)
* Compile SimulatedDeviceSample

```
git clone git@github.com:Roedy13/azure-iot-samples-csharp.git
cd azure-iot-samples-csharp.git
git checkout update-sample-to-supported-dotnet-version
cd iot-hub/Tutorials/Routing/SimulatedDevice/
dotnet restore
dotnet run
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
The code works fine as long as it compiles

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->